### PR TITLE
refactor(macro): use CHECK_* to replace dassert_* (part 3)

### DIFF
--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -30,18 +30,17 @@ namespace block_service {
 
 block_service_registry::block_service_registry()
 {
-    bool ans;
-    ans = utils::factory_store<block_filesystem>::register_factory(
-        "fds_service", block_filesystem::create<fds_service>, PROVIDER_TYPE_MAIN);
-    dassert(ans, "register fds_service failed");
+    CHECK(utils::factory_store<block_filesystem>::register_factory(
+              "fds_service", block_filesystem::create<fds_service>, PROVIDER_TYPE_MAIN),
+          "register fds_service failed");
 
-    ans = utils::factory_store<block_filesystem>::register_factory(
-        "hdfs_service", block_filesystem::create<hdfs_service>, PROVIDER_TYPE_MAIN);
-    dassert(ans, "register hdfs_service failed");
+    CHECK(utils::factory_store<block_filesystem>::register_factory(
+              "hdfs_service", block_filesystem::create<hdfs_service>, PROVIDER_TYPE_MAIN),
+          "register hdfs_service failed");
 
-    ans = utils::factory_store<block_filesystem>::register_factory(
-        "local_service", block_filesystem::create<local_service>, PROVIDER_TYPE_MAIN);
-    dassert(ans, "register local_service failed");
+    CHECK(utils::factory_store<block_filesystem>::register_factory(
+              "local_service", block_filesystem::create<local_service>, PROVIDER_TYPE_MAIN),
+          "register local_service failed");
 }
 
 block_service_manager::block_service_manager()

--- a/src/block_service/fds/fds_service.cpp
+++ b/src/block_service/fds/fds_service.cpp
@@ -407,19 +407,19 @@ error_code fds_file_object::get_file_meta()
 
         // get file length
         auto iter = meta.find(fds_service::FILE_LENGTH_CUSTOM_KEY);
-        dassert_f(iter != meta.end(),
-                  "can't find {} in object({})'s metadata",
-                  fds_service::FILE_LENGTH_CUSTOM_KEY.c_str(),
-                  _fds_path.c_str());
+        CHECK(iter != meta.end(),
+              "can't find {} in object({})'s metadata",
+              fds_service::FILE_LENGTH_CUSTOM_KEY,
+              _fds_path);
         bool valid = dsn::buf2uint64(iter->second, _size);
         CHECK(valid, "error to get file size");
 
         // get md5 key
         iter = meta.find(fds_service::FILE_MD5_KEY);
-        dassert_f(iter != meta.end(),
-                  "can't find {} in object({})'s metadata",
-                  fds_service::FILE_MD5_KEY,
-                  _fds_path);
+        CHECK(iter != meta.end(),
+              "can't find {} in object({})'s metadata",
+              fds_service::FILE_MD5_KEY,
+              _fds_path);
         _md5sum = iter->second;
 
         _has_meta_synced = true;

--- a/src/block_service/local/local_service.cpp
+++ b/src/block_service/local/local_service.cpp
@@ -84,10 +84,9 @@ error_code local_service::initialize(const std::vector<std::string> &args)
             LOG_WARNING("old local block service root dir has already exist, path(%s)",
                         _root.c_str());
         } else {
-            if (!::dsn::utils::filesystem::create_directory(_root)) {
-                dassert(false, "local block service create directory(%s) fail", _root.c_str());
-                return ERR_FS_INTERNAL;
-            }
+            CHECK(::dsn::utils::filesystem::create_directory(_root),
+                  "local block service create directory({}) fail",
+                  _root);
         }
         LOG_INFO("local block service initialize succeed with root(%s)", _root.c_str());
     }

--- a/src/client/partition_resolver.cpp
+++ b/src/client/partition_resolver.cpp
@@ -74,11 +74,11 @@ void partition_resolver::call_task(const rpc_response_task_ptr &t)
                     dynamic_cast<rpc_response_task *>(task::get_current_task());
                 partition_resolver_ptr r(this);
 
-                dassert(ctask != nullptr, "current task must be rpc_response_task");
+                CHECK_NOTNULL(ctask, "current task must be rpc_response_task");
                 ctask->replace_callback(std::move(oc));
-                dassert(ctask->set_retry(false),
-                        "rpc_response_task set retry failed, state = %s",
-                        enum_to_string(ctask->state()));
+                CHECK(ctask->set_retry(false),
+                      "rpc_response_task set retry failed, state = {}",
+                      enum_to_string(ctask->state()));
 
                 // sleep gap milliseconds before retry
                 tasking::enqueue(LPC_RPC_DELAY_CALL,

--- a/src/client/replication_ddl_client.cpp
+++ b/src/client/replication_ddl_client.cpp
@@ -1508,7 +1508,7 @@ replication_ddl_client::set_app_envs(const std::string &app_name,
     if (clear_all) {
         req->__set_clear_prefix("");
     } else {
-        dassert(!prefix.empty(), "prefix can not be empty");
+        CHECK(!prefix.empty(), "prefix can not be empty");
         req->__set_clear_prefix(prefix);
     }
 

--- a/src/client_lib/pegasus_client_impl.cpp
+++ b/src/client_lib/pegasus_client_impl.cpp
@@ -1274,8 +1274,7 @@ void pegasus_client_impl::async_duplicate(dsn::apps::duplicate_rpc rpc,
 const char *pegasus_client_impl::get_error_string(int error_code) const
 {
     auto it = _client_error_to_string.find(error_code);
-    dassert(
-        it != _client_error_to_string.end(), "client error %d have no error string", error_code);
+    CHECK(it != _client_error_to_string.end(), "client error {} have no error string", error_code);
     return it->second.c_str();
 }
 

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -15,15 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "common/common.h"
+#include "common.h"
+
 #include "utils/flags.h"
+#include "utils/fmt_logging.h"
 
 namespace dsn {
 DSN_DEFINE_string("replication", cluster_name, "", "name of this cluster");
 
 /*extern*/ const char *get_current_cluster_name()
 {
-    dassert(strlen(FLAGS_cluster_name) != 0, "cluster_name is not set");
+    CHECK_GT_MSG(strlen(FLAGS_cluster_name), 0, "cluster_name is not set");
     return FLAGS_cluster_name;
 }
 } // namespace dsn

--- a/src/common/duplication_common.cpp
+++ b/src/common/duplication_common.cpp
@@ -48,18 +48,18 @@ const std::string duplication_constants::kDuplicationEnvMasterMetasKey /*NOLINT*
 /*extern*/ const char *duplication_status_to_string(duplication_status::type status)
 {
     auto it = _duplication_status_VALUES_TO_NAMES.find(status);
-    dassert(it != _duplication_status_VALUES_TO_NAMES.end(),
-            "unexpected type of duplication_status: %d",
-            status);
+    CHECK(it != _duplication_status_VALUES_TO_NAMES.end(),
+          "unexpected type of duplication_status: {}",
+          status);
     return it->second;
 }
 
 /*extern*/ const char *duplication_fail_mode_to_string(duplication_fail_mode::type fmode)
 {
     auto it = _duplication_fail_mode_VALUES_TO_NAMES.find(fmode);
-    dassert(it != _duplication_fail_mode_VALUES_TO_NAMES.end(),
-            "unexpected type of duplication_fail_mode: %d",
-            fmode);
+    CHECK(it != _duplication_fail_mode_VALUES_TO_NAMES.end(),
+          "unexpected type of duplication_fail_mode: {}",
+          fmode);
     return it->second;
 }
 

--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -243,11 +243,7 @@ void fs_manager::allocate_dir(const gpid &pid, const std::string &type, /*out*/ 
     unsigned least_total_replicas_count = 0;
 
     for (auto &n : _dir_nodes) {
-        dassert(!n->has(pid),
-                "gpid(%d.%d) already in dir_node(%s)",
-                pid.get_app_id(),
-                pid.get_partition_index(),
-                n->tag.c_str());
+        CHECK(!n->has(pid), "gpid({}) already in dir_node({})", pid, n->tag);
         unsigned app_replicas = n->replicas_count(pid.get_app_id());
         unsigned total_replicas = n->replicas_count();
 

--- a/src/common/json_helper.h
+++ b/src/common/json_helper.h
@@ -522,7 +522,7 @@ inline void json_encode(JsonWriter &out, const std::shared_ptr<T> &t)
 {
     // when a smart ptr is encoded, caller should ensure the ptr is not nullptr
     // TODO: encoded to null?
-    dassert(t.get(), "");
+    CHECK(t, "");
     json_encode(out, *t);
 }
 

--- a/src/common/storage_serverlet.h
+++ b/src/common/storage_serverlet.h
@@ -99,10 +99,10 @@ protected:
 
     static bool register_async_rpc_handler(dsn::task_code rpc_code, const char *name, rpc_handler h)
     {
-        dassert(s_handlers.emplace(rpc_code.to_string(), h).second,
-                "handler %s has already been registered",
-                rpc_code.to_string());
-        dassert(s_handlers.emplace(name, h).second, "handler %s has already been registered", name);
+        CHECK(s_handlers.emplace(rpc_code.to_string(), h).second,
+              "handler {} has already been registered",
+              rpc_code);
+        CHECK(s_handlers.emplace(name, h).second, "handler {} has already been registered", name);
 
         s_vhandlers.resize(rpc_code + 1);
         CHECK(s_vhandlers[rpc_code] == nullptr,

--- a/src/meta/duplication/duplication_info.h
+++ b/src/meta/duplication/duplication_info.h
@@ -251,7 +251,7 @@ extern void json_encode(dsn::json::JsonWriter &out, const duplication_fail_mode:
 
 extern bool json_decode(const dsn::json::JsonObject &in, duplication_fail_mode::type &s);
 
-// TODO(yingchun): remember to update it when refactor dassert_f
+// TODO(yingchun): remember to cleanup dassert_dup
 #define dassert_dup(_pred_, _dup_, ...)                                                            \
     CHECK(_pred_, "[a{}d{}] {}", _dup_->app_id, _dup_->id, fmt::format(__VA_ARGS__));
 

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -109,11 +109,7 @@ const std::string &get_disk_tag(const app_mapper &apps, const rpc_address &node,
 {
     const config_context &cc = *get_config_context(apps, pid);
     auto iter = cc.find_from_serving(node);
-    dassert(iter != cc.serving.end(),
-            "can't find disk tag of gpid(%d.%d) for %s",
-            pid.get_app_id(),
-            pid.get_partition_index(),
-            node.to_string());
+    CHECK(iter != cc.serving.end(), "can't find disk tag of gpid({}) for {}", pid, node);
     return iter->disk_tag;
 }
 
@@ -335,10 +331,7 @@ dsn::gpid load_balance_policy::select_moving(std::list<dsn::gpid> &potential_mov
         }
     }
 
-    dassert_f(selected != potential_moving.end(),
-              "can't find gpid to move from({}) to({})",
-              from.to_string(),
-              to.to_string());
+    CHECK(selected != potential_moving.end(), "can't find gpid to move from({}) to({})", from, to);
     auto res = *selected;
     potential_moving.erase(selected);
     return res;
@@ -556,9 +549,7 @@ void ford_fulkerson::update_decree(int node_id, const node_state &ns)
         const partition_configuration &pc = _app->partitions[pid.get_partition_index()];
         for (const auto &secondary : pc.secondaries) {
             auto i = _address_id.find(secondary);
-            dassert_f(i != _address_id.end(),
-                      "invalid secondary address, address = {}",
-                      secondary.to_string());
+            CHECK(i != _address_id.end(), "invalid secondary address, address = {}", secondary);
             _network[node_id][i->second]++;
         }
         return true;

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -147,9 +147,10 @@ bool construct_replica(meta_view view, const gpid &pid, int max_replica_count)
 
     // treat last server in drop_list as the primary
     const dropped_replica &server = drop_list.back();
-    dassert(server.ballot != invalid_ballot,
-            "the ballot of server must not be invalid_ballot, node = %s",
-            server.node.to_string());
+    CHECK_NE_MSG(server.ballot,
+                 invalid_ballot,
+                 "the ballot of server must not be invalid_ballot, node = {}",
+                 server.node);
     pc.primary = server.node;
     pc.ballot = server.ballot;
     pc.partition_flags = 0;

--- a/src/meta/meta_options.cpp
+++ b/src/meta/meta_options.cpp
@@ -84,9 +84,10 @@ void meta_options::initialize()
             break;
         }
     }
-    dassert(meta_function_level_on_start != meta_function_level::fl_invalid,
-            "invalid function level: %s",
-            level_str);
+    CHECK_NE_MSG(meta_function_level_on_start,
+                 meta_function_level::fl_invalid,
+                 "invalid function level: {}",
+                 level_str);
 
     recover_from_replica_server = dsn_config_get_value_bool(
         "meta_server",

--- a/src/replica/duplication/mutation_batch.cpp
+++ b/src/replica/duplication/mutation_batch.cpp
@@ -59,7 +59,7 @@ void mutation_buffer::commit(decree d, commit_type ct)
         //                |                                |
         //             n+m(m>1)            n+k(k>=m)
         //
-        // just LOG_ERROR but not dassert if mutation loss or other problem, it's different from
+        // just LOG_ERROR but not CHECK if mutation loss or other problem, it's different from
         // base class implement. And from the error and perf-counter, we can choose restart
         // duplication
         // or ignore the loss.

--- a/src/replica/log_block.h
+++ b/src/replica/log_block.h
@@ -60,7 +60,7 @@ public:
     // ```
     blob &front()
     {
-        dassert(!_data.empty(), "trying to get first blob out of an empty log block");
+        CHECK(!_data.empty(), "trying to get first blob out of an empty log block");
         return _data.front();
     }
 

--- a/src/replica/log_file.cpp
+++ b/src/replica/log_file.cpp
@@ -51,7 +51,7 @@ log_file::~log_file() { close(); }
     }
 
     auto pos = name.find_first_of('.');
-    dassert(pos != std::string::npos, "invalid log_file, name = %s", name.c_str());
+    CHECK(pos != std::string::npos, "invalid log_file, name = {}", name);
     auto pos2 = name.find_first_of('.', pos + 1);
     if (pos2 == std::string::npos) {
         err = ERR_INVALID_PARAMETERS;
@@ -163,9 +163,7 @@ log_file::log_file(
 
     if (is_read) {
         int64_t sz;
-        if (!dsn::utils::filesystem::file_size(_path, sz)) {
-            dassert(false, "fail to get file size of %s.", _path.c_str());
-        }
+        CHECK(dsn::utils::filesystem::file_size(_path, sz), "fail to get file size of {}.", _path);
         _end_offset += sz;
     }
 }
@@ -187,7 +185,7 @@ void log_file::close()
 
 void log_file::flush() const
 {
-    dassert(!_is_read, "log file must be of write mode");
+    CHECK(!_is_read, "log file must be of write mode");
     zauto_lock lock(_write_lock);
 
     if (_handle) {
@@ -198,7 +196,7 @@ void log_file::flush() const
 
 error_code log_file::read_next_log_block(/*out*/ ::dsn::blob &bb)
 {
-    dassert(_is_read, "log file must be of read mode");
+    CHECK(_is_read, "log file must be of read mode");
     auto err = _stream->read_next(sizeof(log_block_header), bb);
     if (err != ERR_OK || bb.length() != sizeof(log_block_header)) {
         if (err == ERR_OK || err == ERR_HANDLE_EOF) {
@@ -262,7 +260,7 @@ aio_task_ptr log_file::commit_log_blocks(log_appender &pending,
                                          aio_handler &&callback,
                                          int hash)
 {
-    dassert(!_is_read, "log file must be of write mode");
+    CHECK(!_is_read, "log file must be of write mode");
     CHECK_GT(pending.size(), 0);
 
     zauto_lock lock(_write_lock);

--- a/src/replica/log_file_stream.h
+++ b/src/replica/log_file_stream.h
@@ -93,7 +93,7 @@ public:
         } else {
             _current_buffer->drain(writer);
             // we can now assign result since writer must have allocated a buffer.
-            dassert(writer.total_size() != 0, "writer.total_size = %d", writer.total_size());
+            CHECK_GT(writer.total_size(), 0);
             if (size > writer.total_size()) {
                 TRY(_next_buffer->wait_ongoing_task());
                 _next_buffer->consume(writer,

--- a/src/replica/mutation.cpp
+++ b/src/replica/mutation.cpp
@@ -159,8 +159,7 @@ void mutation::add_client_request(task_code code, dsn::message_ex *request)
 
         void *ptr;
         size_t size;
-        bool r = request->read_next(&ptr, &size);
-        dassert(r, "payload is not present");
+        CHECK(request->read_next(&ptr, &size), "payload is not present");
         request->read_commit(0); // so we can re-read the request buffer in replicated app
         update.data.assign((char *)ptr, 0, (int)size);
 
@@ -235,7 +234,7 @@ void mutation::write_to(binary_writer &writer, dsn::message_ex * /*to*/) const
         std::string name;
         reader.read(name);
         ::dsn::task_code code = dsn::task_code::try_get(name, TASK_CODE_INVALID);
-        dassert(code != TASK_CODE_INVALID, "invalid mutation task code: %s", name.c_str());
+        CHECK_NE_MSG(code, TASK_CODE_INVALID, "invalid mutation task code: {}", name);
         mu->data.updates[i].code = code;
 
         int type = 0;
@@ -312,7 +311,7 @@ void mutation::write_to(binary_writer &writer, dsn::message_ex * /*to*/) const
         reader.read_pod(isset);
         header.timestamp = 0;
     } else {
-        dassert(false, "invalid mutation log version: 0x%" PRIx64, version);
+        CHECK(false, "invalid mutation log version: {:#018x}", version);
     }
 }
 
@@ -343,7 +342,7 @@ mutation_queue::mutation_queue(gpid gpid,
 {
     _current_op_count = 0;
     _pending_mutation = nullptr;
-    dassert(gpid.get_app_id() != 0, "invalid gpid");
+    CHECK_NE_MSG(gpid.get_app_id(), 0, "invalid gpid");
     _pcount = dsn_task_queue_virtual_length_ptr(RPC_PREPARE, gpid.thread_hash());
 }
 
@@ -392,7 +391,7 @@ mutation_ptr mutation_queue::add_work(task_code code, dsn::message_ex *request, 
     if (_current_op_count >= _max_concurrent_op)
         return nullptr;
     else if (_hdr.is_empty()) {
-        dassert(_pending_mutation != nullptr, "pending mutation cannot be null");
+        CHECK_NOTNULL(_pending_mutation, "pending mutation cannot be null");
 
         auto ret = _pending_mutation;
         _pending_mutation = nullptr;

--- a/src/replica/mutation.h
+++ b/src/replica/mutation.h
@@ -97,7 +97,7 @@ public:
     void copy_from(mutation_ptr &old);
     void set_logged()
     {
-        dassert(!is_logged(), "");
+        CHECK(!is_logged(), "");
         _not_logged = 0;
     }
     unsigned int decrease_left_secondary_ack_count() { return --_left_secondary_ack_count; }
@@ -200,10 +200,10 @@ public:
     ~mutation_queue()
     {
         clear();
-        dassert(_hdr.is_empty(),
-                "work queue is deleted when there are still %d running ops or pending work items "
-                "in queue",
-                _current_op_count);
+        CHECK(_hdr.is_empty(),
+              "work queue is deleted when there are still {} running ops or pending work items "
+              "in queue",
+              _current_op_count);
     }
 
     mutation_ptr add_work(task_code code, dsn::message_ex *request, replica *r);

--- a/src/replica/mutation_cache.cpp
+++ b/src/replica/mutation_cache.cpp
@@ -110,7 +110,7 @@ mutation_ptr mutation_cache::pop_min()
 
         if (_interval == 0) {
             // TODO: FIXE ME LATER
-            // dassert (_total_size_bytes == 0, "");
+            // CHECK_EQ(_total_size_bytes, 0);
 
             _end_decree = _start_decree;
             _end_idx = _start_idx;

--- a/src/replica/mutation_log_replay.cpp
+++ b/src/replica/mutation_log_replay.cpp
@@ -93,7 +93,7 @@ namespace replication {
     while (!reader->is_eof()) {
         auto old_size = reader->get_remaining_size();
         mutation_ptr mu = mutation::read_from(*reader, nullptr);
-        dassert(nullptr != mu, "");
+        CHECK_NOTNULL(mu, "");
         mu->set_logged();
 
         if (mu->data.header.log_offset != end_offset) {
@@ -131,8 +131,7 @@ namespace replication {
             }
         }
 
-        dassert(
-            logs.find(log->index()) == logs.end(), "invalid log_index, index = %d", log->index());
+        CHECK(logs.find(log->index()) == logs.end(), "invalid log index, index = {}", log->index());
         logs[log->index()] = log;
     }
 

--- a/src/replica/prepare_list.cpp
+++ b/src/replica/prepare_list.cpp
@@ -116,7 +116,7 @@ error_code prepare_list::prepare(mutation_ptr &mu,
     //        else
     //            break;
     //    }
-    //    dassert (err == ERR_OK, "");
+    //    CHECK_EQ(err, ERR_OK);
     //    return err;
 
     case partition_status::PS_INACTIVE: // only possible during init
@@ -135,7 +135,7 @@ error_code prepare_list::prepare(mutation_ptr &mu,
         return err;
 
     default:
-        dassert(false, "invalid partition_status, status = %s", enum_to_string(status));
+        CHECK(false, "invalid partition_status, status = {}", enum_to_string(status));
         return dsn::ERR_OK;
     }
 }
@@ -196,7 +196,7 @@ void prepare_list::commit(decree d, commit_type ct)
         return;
     }
     default:
-        dassert(false, "invalid commit type %d", (int)ct);
+        CHECK(false, "invalid commit type {}", (int)ct);
     }
 
     return;

--- a/src/replica/prepare_list.cpp
+++ b/src/replica/prepare_list.cpp
@@ -196,7 +196,7 @@ void prepare_list::commit(decree d, commit_type ct)
         return;
     }
     default:
-        CHECK(false, "invalid commit type {}", (int)ct);
+        CHECK(false, "invalid commit type {}", ct);
     }
 
     return;

--- a/src/replica/replica_2pc.cpp
+++ b/src/replica/replica_2pc.cpp
@@ -482,8 +482,11 @@ void replica::on_prepare(dsn::message_ex *request)
 
     if (partition_status::PS_POTENTIAL_SECONDARY == status() ||
         partition_status::PS_SECONDARY == status()) {
-        CHECK_LE(mu->data.header.decree,
-                 last_committed_decree() + _options->max_mutation_count_in_prepare_list);
+        CHECK_LE_MSG(mu->data.header.decree,
+                     last_committed_decree() + _options->max_mutation_count_in_prepare_list,
+                     "last_committed_decree: {}, _options->max_mutation_count_in_prepare_list: {}",
+                     last_committed_decree(),
+                     _options->max_mutation_count_in_prepare_list);
     } else {
         LOG_ERROR("%s: mutation %s on_prepare failed as invalid replica state, state = %s",
                   name(),

--- a/src/replica/replica_backup.cpp
+++ b/src/replica/replica_backup.cpp
@@ -72,7 +72,7 @@ void replica::on_cold_backup(const backup_request &request, /*out*/ backup_respo
                 return;
             }
             auto r = _cold_backup_contexts.insert(std::make_pair(policy_name, new_context));
-            dassert(r.second, "");
+            CHECK(r.second, "");
             backup_context = r.first->second;
             backup_context->block_service = block_service;
             backup_context->backup_root = request.__isset.backup_path
@@ -325,11 +325,11 @@ static bool filter_checkpoint(const std::string &dir,
         if (ret == 1) {
             related_chkpt_dirs.emplace_back(std::move(dirname));
         } else if (ret == 2) {
-            dassert(valid_chkpt_dir.empty(),
-                    "%s: there are two valid backup checkpoint dir, %s VS %s",
-                    backup_context->name,
-                    valid_chkpt_dir.c_str(),
-                    dirname.c_str());
+            CHECK(valid_chkpt_dir.empty(),
+                  "{}: there are two valid backup checkpoint dir, {} VS {}",
+                  backup_context->name,
+                  valid_chkpt_dir,
+                  dirname);
             valid_chkpt_dir = dirname;
         }
     }
@@ -427,11 +427,11 @@ void replica::generate_backup_checkpoint(cold_backup_context_ptr backup_context)
         // parse checkpoint dirname
         std::string policy_name;
         int64_t backup_id = 0, decree = 0, timestamp = 0;
-        dassert(backup_parse_dir_name(
-                    valid_backup_chkpt_dirname.c_str(), policy_name, backup_id, decree, timestamp),
-                "%s: valid chekpoint dirname %s",
-                backup_context->name,
-                valid_backup_chkpt_dirname.c_str());
+        CHECK(backup_parse_dir_name(
+                  valid_backup_chkpt_dirname.c_str(), policy_name, backup_id, decree, timestamp),
+              "{}: valid chekpoint dirname {}",
+              backup_context->name,
+              valid_backup_chkpt_dirname);
 
         if (statistic_file_infos_under_dir(valid_chkpt_full_path, file_infos, total_size)) {
             backup_context->checkpoint_decree = decree;

--- a/src/replica/replica_check.cpp
+++ b/src/replica/replica_check.cpp
@@ -73,7 +73,7 @@ void replica::broadcast_group_check()
 {
     FAIL_POINT_INJECT_F("replica_broadcast_group_check", [](dsn::string_view) {});
 
-    dassert(nullptr != _primary_states.group_check_task, "");
+    CHECK_NOTNULL(_primary_states.group_check_task, "");
 
     LOG_INFO("%s: start to broadcast group check", name());
 
@@ -115,8 +115,7 @@ void replica::broadcast_group_check()
 
         if (request->config.status == partition_status::PS_POTENTIAL_SECONDARY) {
             auto it = _primary_states.learners.find(addr);
-            dassert(
-                it != _primary_states.learners.end(), "learner %s is missing", addr.to_string());
+            CHECK(it != _primary_states.learners.end(), "learner {} is missing", addr);
             request->config.learner_signature = it->second.signature;
         }
 
@@ -195,7 +194,7 @@ void replica::on_group_check(const group_check_request &request,
     case partition_status::PS_ERROR:
         break;
     default:
-        dassert(false, "invalid partition_status, status = %s", enum_to_string(status()));
+        CHECK(false, "invalid partition_status, status = {}", enum_to_string(status()));
     }
 
     response.pid = get_gpid();

--- a/src/replica/replica_chkpt.cpp
+++ b/src/replica/replica_chkpt.cpp
@@ -235,7 +235,7 @@ error_code replica::background_async_checkpoint(bool is_emergency)
     decree old_durable = _app->last_durable_decree();
     auto err = _app->async_checkpoint(is_emergency);
     uint64_t used_time = dsn_now_ns() - start_time;
-    dassert(err != ERR_NOT_IMPLEMENTED, "err == ERR_NOT_IMPLEMENTED");
+    CHECK_NE(err, ERR_NOT_IMPLEMENTED);
     if (err == ERR_OK) {
         if (old_durable != _app->last_durable_decree()) {
             // if no need to generate new checkpoint, async_checkpoint() also returns ERR_OK,
@@ -303,7 +303,7 @@ error_code replica::background_sync_checkpoint()
     decree old_durable = _app->last_durable_decree();
     auto err = _app->sync_checkpoint();
     uint64_t used_time = dsn_now_ns() - start_time;
-    dassert(err != ERR_NOT_IMPLEMENTED, "err == ERR_NOT_IMPLEMENTED");
+    CHECK_NE(err, ERR_NOT_IMPLEMENTED);
     if (err == ERR_OK) {
         if (old_durable != _app->last_durable_decree()) {
             // if no need to generate new checkpoint, sync_checkpoint() also returns ERR_OK,
@@ -390,7 +390,7 @@ void replica::on_checkpoint_completed(error_code err)
         if (_app->last_committed_decree() > _prepare_list->min_decree()) {
             for (auto d = _app->last_committed_decree() + 1; d <= c; d++) {
                 auto mu = _prepare_list->get_mutation_by_decree(d);
-                dassert(nullptr != mu, "invalid mutation, decree = %" PRId64, d);
+                CHECK_NOTNULL(mu, "invalid mutation, decree = {}", d);
                 err = _app->apply_mutation(mu);
                 if (ERR_OK != err) {
                     _secondary_states.checkpoint_is_running = false;

--- a/src/replica/replica_context.cpp
+++ b/src/replica/replica_context.cpp
@@ -147,7 +147,7 @@ bool primary_context::check_exist(::dsn::rpc_address node, partition_status::typ
     case partition_status::PS_POTENTIAL_SECONDARY:
         return learners.find(node) != learners.end();
     default:
-        dassert(false, "invalid partition_status, status = %s", enum_to_string(st));
+        CHECK(false, "invalid partition_status, status = {}", enum_to_string(st));
         return false;
     }
 }

--- a/src/replica/replica_context.h
+++ b/src/replica/replica_context.h
@@ -68,8 +68,8 @@ typedef std::unordered_map<::dsn::rpc_address, remote_learner_state> learner_map
         if (t != nullptr) {                                                                        \
             bool finished;                                                                         \
             t->cancel(false, &finished);                                                           \
-            dassert(finished || dsn_task_is_running_inside(task_.get()),                           \
-                    "task must be finished at this point");                                        \
+            CHECK(finished || dsn_task_is_running_inside(task_.get()),                             \
+                  "task must be finished at this point");                                          \
             task_ = nullptr;                                                                       \
         }                                                                                          \
     }

--- a/src/replica/replica_failover.cpp
+++ b/src/replica/replica_failover.cpp
@@ -68,15 +68,14 @@ void replica::handle_remote_failure(partition_status::type st,
               node.to_string());
 
     CHECK_EQ(status(), partition_status::PS_PRIMARY);
-    dassert(
-        node != _stub->_primary_address, "%s VS %s", node.to_string(), _stub->_primary_address_str);
+    CHECK_NE(node, _stub->_primary_address);
 
     switch (st) {
     case partition_status::PS_SECONDARY:
-        dassert(_primary_states.check_exist(node, partition_status::PS_SECONDARY),
-                "invalid node address, address = %s, status = %s",
-                node.to_string(),
-                enum_to_string(st));
+        CHECK(_primary_states.check_exist(node, partition_status::PS_SECONDARY),
+              "invalid node address, address = {}, status = {}",
+              node,
+              enum_to_string(st));
         {
             configuration_update_request request;
             request.node = node;
@@ -96,7 +95,7 @@ void replica::handle_remote_failure(partition_status::type st,
     case partition_status::PS_ERROR:
         break;
     default:
-        dassert(false, "invalid partition_status, status = %s", enum_to_string(st));
+        CHECK(false, "invalid partition_status, status = {}", enum_to_string(st));
         break;
     }
 }

--- a/src/replica/replica_http_service.h
+++ b/src/replica/replica_http_service.h
@@ -65,7 +65,7 @@ public:
         case manual_compaction_status::FINISHED:
             return "finished";
         default:
-            dassert(false, "invalid status({})", status);
+            CHECK(false, "invalid status({})", status);
             __builtin_unreachable();
         }
     }

--- a/src/replica/replica_restore.cpp
+++ b/src/replica/replica_restore.cpp
@@ -308,41 +308,35 @@ dsn::error_code replica::restore_checkpoint()
     // first check the parameter
     configuration_restore_request restore_req;
     auto iter = _app_info.envs.find(backup_restore_constant::BLOCK_SERVICE_PROVIDER);
-    dassert(iter != _app_info.envs.end(),
-            "%s: can't find %s in app_info.envs",
-            name(),
-            backup_restore_constant::BLOCK_SERVICE_PROVIDER.c_str());
+    dassert_replica(iter != _app_info.envs.end(),
+                    "can't find {} in app_info.envs",
+                    backup_restore_constant::BLOCK_SERVICE_PROVIDER);
     restore_req.backup_provider_name = iter->second;
     iter = _app_info.envs.find(backup_restore_constant::CLUSTER_NAME);
-    dassert(iter != _app_info.envs.end(),
-            "%s: can't find %s in app_info.envs",
-            name(),
-            backup_restore_constant::CLUSTER_NAME.c_str());
+    dassert_replica(iter != _app_info.envs.end(),
+                    "can't find {} in app_info.envs",
+                    backup_restore_constant::CLUSTER_NAME);
     restore_req.cluster_name = iter->second;
     iter = _app_info.envs.find(backup_restore_constant::POLICY_NAME);
-    dassert(iter != _app_info.envs.end(),
-            "%s: can't find %s in app_info.envs",
-            name(),
-            backup_restore_constant::POLICY_NAME.c_str());
+    dassert_replica(iter != _app_info.envs.end(),
+                    "can't find {} in app_info.envs",
+                    backup_restore_constant::POLICY_NAME);
     restore_req.policy_name = iter->second;
     iter = _app_info.envs.find(backup_restore_constant::APP_NAME);
-    dassert(iter != _app_info.envs.end(),
-            "%s: can't find %s in app_info.envs",
-            name(),
-            backup_restore_constant::APP_NAME.c_str());
+    dassert_replica(iter != _app_info.envs.end(),
+                    "can't find {} in app_info.envs",
+                    backup_restore_constant::APP_NAME);
     restore_req.app_name = iter->second;
     iter = _app_info.envs.find(backup_restore_constant::APP_ID);
-    dassert(iter != _app_info.envs.end(),
-            "%s: can't find %s in app_info.envs",
-            name(),
-            backup_restore_constant::APP_ID.c_str());
+    dassert_replica(iter != _app_info.envs.end(),
+                    "can't find {} in app_info.envs",
+                    backup_restore_constant::APP_ID);
     restore_req.app_id = boost::lexical_cast<int32_t>(iter->second);
 
     iter = _app_info.envs.find(backup_restore_constant::BACKUP_ID);
-    dassert(iter != _app_info.envs.end(),
-            "%s: can't find %s in app_info.envs",
-            name(),
-            backup_restore_constant::BACKUP_ID.c_str());
+    dassert_replica(iter != _app_info.envs.end(),
+                    "can't find {} in app_info.envs",
+                    backup_restore_constant::BACKUP_ID);
     restore_req.time_stamp = boost::lexical_cast<int64_t>(iter->second);
 
     bool skip_bad_partition = false;

--- a/src/replica/replication_app_base.cpp
+++ b/src/replica/replication_app_base.cpp
@@ -308,7 +308,7 @@ error_code replication_app_base::open()
 
     std::unique_ptr<char *[]> argvs = make_unique<char *[]>(argc);
     char **argv = argvs.get();
-    dassert(argv != nullptr, "");
+    CHECK_NOTNULL(argv, "");
     int idx = 0;
     argv[idx++] = (char *)(info->app_name.c_str());
     if (argc > 1) {

--- a/src/replica/split/replica_split_manager.cpp
+++ b/src/replica/split/replica_split_manager.cpp
@@ -499,7 +499,7 @@ void replica_split_manager::child_catch_up_states() // on child partition
                                _replica->_prepare_list->min_decree());
             for (decree d = local_decree + 1; d <= goal_decree; ++d) {
                 auto mu = _replica->_prepare_list->get_mutation_by_decree(d);
-                dassert(mu != nullptr, "");
+                CHECK_NOTNULL(mu, "");
                 error_code ec = _replica->_app->apply_mutation(mu);
                 if (ec != ERR_OK) {
                     child_handle_split_error("child_catchup failed because apply mutation failed");

--- a/src/replica/storage/simple_kv/test/case.cpp
+++ b/src/replica/storage/simple_kv/test/case.cpp
@@ -331,7 +331,7 @@ struct event_type_helper
     const char *get(event_type type)
     {
         auto it = type_to_name.find(type);
-        dassert(it != type_to_name.end(), "");
+        CHECK(it != type_to_name.end(), "");
         return it->second.c_str();
     }
     bool get(const std::string &name, event_type &type)
@@ -423,7 +423,7 @@ event *event::parse(int line_no, const std::string &params)
         e = new event_on_rpc_response_enqueue();
         break;
     default:
-        dassert(false, "");
+        CHECK(false, "");
     }
     if (!e->internal_parse(kv_map)) {
         std::cerr << "bad line: line_no=" << line_no
@@ -712,10 +712,9 @@ bool modify_case_line::parse(const std::string &params)
     if (!event_case_line::parse(params))
         return false;
     size_t pos = params.find(':');
-    dassert(pos != std::string::npos, "");
+    CHECK(pos != std::string::npos, "");
     std::map<std::string, std::string> kv_map;
-    bool parse_ret = parse_kv_map(line_no(), params.substr(pos + 1), kv_map);
-    dassert(parse_ret, "");
+    CHECK(parse_kv_map(line_no(), params.substr(pos + 1), kv_map), "");
     std::map<std::string, std::string>::const_iterator it;
     if ((it = kv_map.find("modify_delay")) != kv_map.end())
         _modify_delay = it->second;
@@ -726,8 +725,8 @@ void modify_case_line::modify(const event *ev)
 {
     if (!_modify_delay.empty()) {
         const event_on_task *e = dynamic_cast<const event_on_task *>(ev);
-        dassert(e != nullptr, "");
-        dassert(e->_task != nullptr, "");
+        CHECK_NOTNULL(e, "");
+        CHECK_NOTNULL(e->_task, "");
         e->_task->set_delay(boost::lexical_cast<int>(_modify_delay));
     }
 }
@@ -760,7 +759,7 @@ std::string client_case_line::to_string() const
         break;
     }
     default:
-        dassert(false, "");
+        CHECK(false, "");
     }
     return oss.str();
 }
@@ -825,7 +824,7 @@ bool client_case_line::parse(const std::string &params)
         break;
     }
     default:
-        dassert(false, "");
+        CHECK(false, "");
     }
     if (!parse_ok) {
         std::cerr << "bad line: line_no=" << line_no() << ": unknown error: " << kv_map["err"]
@@ -849,7 +848,7 @@ std::string client_case_line::type_name() const
     case replica_config:
         return "replica_config";
     default:
-        dassert(false, "");
+        CHECK(false, "");
     }
     return "";
 }
@@ -1104,7 +1103,7 @@ void test_case::print(case_line *cl, const std::string &other, bool is_skip)
     }
 
     if (cl == nullptr) {
-        dassert(!other.empty(), "");
+        CHECK(!other.empty(), "");
         std::cout << "    +  " << other << std::endl;
     } else // cl != nullptr
     {

--- a/src/replica/storage/simple_kv/test/checker.cpp
+++ b/src/replica/storage/simple_kv/test/checker.cpp
@@ -271,7 +271,7 @@ void test_checker::on_replica_state_change(::dsn::rpc_address from,
 void test_checker::on_config_change(const app_mapper &new_config)
 {
     const partition_configuration *pc = get_config(new_config, g_default_gpid);
-    dassert(pc != nullptr, "drop table is not allowed in test");
+    CHECK_NOTNULL(pc, "drop table is not allowed in test");
 
     parti_config cur_config;
     cur_config.convert_from(*pc);

--- a/src/replica/storage/simple_kv/test/common.cpp
+++ b/src/replica/storage/simple_kv/test/common.cpp
@@ -66,7 +66,7 @@ const char *partition_status_to_short_string(partition_status::type s)
     case partition_status::PS_INVALID:
         return "inv";
     default:
-        dassert(false, "invalid partition_status, status = %s", ::dsn::enum_to_string(s));
+        CHECK(false, "invalid partition_status, status = {}", ::dsn::enum_to_string(s));
         return "";
     }
 }
@@ -85,7 +85,7 @@ partition_status::type partition_status_from_short_string(const std::string &str
         return partition_status::PS_POTENTIAL_SECONDARY;
     if (str == "inv")
         return partition_status::PS_INVALID;
-    dassert(false, "");
+    CHECK(false, "");
     return partition_status::PS_INVALID;
 }
 
@@ -93,7 +93,7 @@ std::string address_to_node(rpc_address addr)
 {
     if (addr.is_invalid())
         return "-";
-    dassert(test_checker::s_inited, "");
+    CHECK(test_checker::s_inited, "");
     return test_checker::instance().address_to_node_name(addr);
 }
 
@@ -101,7 +101,7 @@ rpc_address node_to_address(const std::string &name)
 {
     if (name == "-")
         return rpc_address();
-    dassert(test_checker::s_inited, "");
+    CHECK(test_checker::s_inited, "");
     return test_checker::instance().node_name_to_address(name);
 }
 

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
@@ -115,7 +115,7 @@ void simple_kv_service_impl::on_append(const kv_pair &pr, ::dsn::rpc_replier<int
 
     dsn::zauto_lock l(_lock);
     if (clear_state) {
-        CHECK(dsn::utils::filesystem::remove_path(data_dir().c_str()),
+        CHECK(dsn::utils::filesystem::remove_path(data_dir()),
               "Fail to delete directory {}",
               data_dir());
         _store.clear();

--- a/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.server.impl.cpp
@@ -115,9 +115,9 @@ void simple_kv_service_impl::on_append(const kv_pair &pr, ::dsn::rpc_replier<int
 
     dsn::zauto_lock l(_lock);
     if (clear_state) {
-        if (!dsn::utils::filesystem::remove_path(data_dir().c_str())) {
-            dassert(false, "Fail to delete directory %s.", data_dir().c_str());
-        }
+        CHECK(dsn::utils::filesystem::remove_path(data_dir().c_str()),
+              "Fail to delete directory {}",
+              data_dir());
         _store.clear();
         reset_state();
     }
@@ -137,9 +137,9 @@ void simple_kv_service_impl::recover()
 
     std::vector<std::string> sub_list;
     std::string path = data_dir();
-    if (!dsn::utils::filesystem::get_subfiles(path, sub_list, false)) {
-        dassert(false, "Fail to get subfiles in %s.", path.c_str());
-    }
+    CHECK(dsn::utils::filesystem::get_subfiles(path, sub_list, false),
+          "Fail to get subfiles in {}",
+          path);
     for (auto &fpath : sub_list) {
         auto &&s = dsn::utils::filesystem::get_file_name(fpath);
         if (s.substr(0, strlen("checkpoint.")) != std::string("checkpoint."))

--- a/src/replica/test/replica_test.cpp
+++ b/src/replica/test/replica_test.cpp
@@ -189,11 +189,7 @@ public:
     {
         const auto reserved_max_replica_count = _app_info.max_replica_count;
         const int32_t target_max_replica_count = 5;
-        dassert_f(target_max_replica_count != reserved_max_replica_count,
-                  "target_max_replica_count should not be equal to reserved_max_replica_count:"
-                  "target_max_replica_count={}, reserved_max_replica_count={}",
-                  target_max_replica_count,
-                  reserved_max_replica_count);
+        CHECK_NE(target_max_replica_count, reserved_max_replica_count);
 
         // store new max_replica_count into file
         _mock_replica->update_app_max_replica_count(target_max_replica_count);

--- a/src/runtime/fault_injector.cpp
+++ b/src/runtime/fault_injector.cpp
@@ -318,7 +318,7 @@ void fault_injector::install(service_spec &spec)
         std::string section_name =
             std::string("task.") + std::string(dsn::task_code(i).to_string());
         task_spec *spec = task_spec::get(i);
-        dassert(spec != nullptr, "task_spec cannot be null");
+        CHECK_NOTNULL(spec, "");
 
         fj_opt &lopt = s_fj_opts[i];
         read_config(section_name.c_str(), lopt, &default_opt);

--- a/src/runtime/pipeline.h
+++ b/src/runtime/pipeline.h
@@ -108,7 +108,7 @@ struct result
     //
     void step_down_next_stage(Args &&... args)
     {
-        dassert(__func != nullptr, "no next stage is linked");
+        CHECK_NOTNULL(__func, "no next stage is linked");
         __func(std::make_tuple(std::forward<Args>(args)...));
     }
 
@@ -264,7 +264,7 @@ struct when : environment
 
 inline void base::run_pipeline()
 {
-    dassert(__conf.tracker != nullptr, "must configure task tracker");
+    CHECK_NOTNULL(__conf.tracker, "must configure task tracker");
 
     _paused.store(false, std::memory_order_release);
 

--- a/src/runtime/profiler.cpp
+++ b/src/runtime/profiler.cpp
@@ -131,8 +131,7 @@ static void profiler_on_task_enqueue(task *caller, task *callee)
 
     if (caller != nullptr) {
         auto caller_code = caller->spec().code;
-        dassert(
-            caller_code >= 0 && caller_code <= s_task_code_max, "code = %d", caller_code.code());
+        CHECK(caller_code >= 0 && caller_code <= s_task_code_max, "code = {}", caller_code.code());
 
         auto &prof = s_spec_profilers[caller_code];
         if (prof.collect_call_count) {
@@ -203,8 +202,7 @@ static void profiler_on_aio_call(task *caller, aio_task *callee)
 {
     if (nullptr != caller) {
         auto caller_code = caller->spec().code;
-        dassert(
-            caller_code >= 0 && caller_code <= s_task_code_max, "code = %d", caller_code.code());
+        CHECK(caller_code >= 0 && caller_code <= s_task_code_max, "code = {}", caller_code.code());
 
         auto &prof = s_spec_profilers[caller_code];
         if (prof.collect_call_count) {
@@ -243,8 +241,7 @@ static void profiler_on_rpc_call(task *caller, message_ex *req, rpc_response_tas
 {
     if (nullptr != caller) {
         auto caller_code = caller->spec().code;
-        dassert(
-            caller_code >= 0 && caller_code <= s_task_code_max, "code = %d", caller_code.code());
+        CHECK(caller_code >= 0 && caller_code <= s_task_code_max, "code = {}", caller_code.code());
 
         auto &prof = s_spec_profilers[caller_code];
         if (prof.collect_call_count) {
@@ -311,7 +308,7 @@ static void profiler_on_rpc_reply(task *caller, message_ex *msg)
     uint64_t qts = message_ext_for_profiler::get(msg);
     uint64_t now = dsn_now_ns();
     task_spec *spec = task_spec::get(msg->local_rpc_code);
-    dassert(spec != nullptr, "task_spec cannot be null, code = %d", msg->local_rpc_code.code());
+    CHECK_NOTNULL(spec, "task_spec cannot be null, code = {}", msg->local_rpc_code.code());
     auto code = spec->rpc_paired_code;
     CHECK(code >= 0 && code <= s_task_code_max, "code = {}", code.code());
     auto ptr = s_spec_profilers[code].ptr[RPC_SERVER_LATENCY_NS].get();
@@ -371,7 +368,7 @@ void profiler::install(service_spec &)
         std::string name(dsn::task_code(i).to_string());
         std::string section_name = std::string("task.") + name;
         task_spec *spec = task_spec::get(i);
-        dassert(spec != nullptr, "task_spec cannot be null");
+        CHECK_NOTNULL(spec, "");
 
         s_spec_profilers[i].collect_call_count = dsn_config_get_value_bool(
             section_name.c_str(),

--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -88,9 +88,7 @@ error_code asio_network_provider::start(rpc_channel channel, int port, bool clie
             boost::asio::io_service::work work(*_io_services[i]);
             boost::system::error_code ec;
             _io_services[i]->run(ec);
-            if (ec) {
-                dassert(false, "boost::asio::io_service run failed: err(%s)", ec.message().data());
-            }
+            CHECK(!ec, "boost::asio::io_service run failed: err({})", ec.message().data());
         }));
     }
 
@@ -396,9 +394,7 @@ error_code asio_udp_provider::start(rpc_channel channel, int port, bool client_o
             boost::asio::io_service::work work(_io_service);
             boost::system::error_code ec;
             _io_service.run(ec);
-            if (ec) {
-                dassert(false, "boost::asio::io_service run failed: err(%s)", ec.message().data());
-            }
+            CHECK(!ec, "boost::asio::io_service run failed: err({})", ec.message().data());
         }));
     }
 

--- a/src/runtime/rpc/asio_net_provider.cpp
+++ b/src/runtime/rpc/asio_net_provider.cpp
@@ -88,7 +88,7 @@ error_code asio_network_provider::start(rpc_channel channel, int port, bool clie
             boost::asio::io_service::work work(*_io_services[i]);
             boost::system::error_code ec;
             _io_services[i]->run(ec);
-            CHECK(!ec, "boost::asio::io_service run failed: err({})", ec.message().data());
+            CHECK(!ec, "boost::asio::io_service run failed: err({})", ec.message());
         }));
     }
 
@@ -394,7 +394,7 @@ error_code asio_udp_provider::start(rpc_channel channel, int port, bool client_o
             boost::asio::io_service::work work(_io_service);
             boost::system::error_code ec;
             _io_service.run(ec);
-            CHECK(!ec, "boost::asio::io_service run failed: err({})", ec.message().data());
+            CHECK(!ec, "boost::asio::io_service run failed: err({})", ec.message());
         }));
     }
 

--- a/src/runtime/rpc/message_parser.cpp
+++ b/src/runtime/rpc/message_parser.cpp
@@ -112,12 +112,11 @@ std::string header_type::debug_string() const
 {
     auto it = s_fmt_map.find(sig);
     if (it != s_fmt_map.end()) {
-        if (it->second != type) {
-            dassert(false,
-                    "signature %08x is already registerd for header type %s",
-                    sig,
-                    type.to_string());
-        }
+        CHECK_EQ_MSG(it->second,
+                     type,
+                     "signature {:#010x} is already registerd for header type {}",
+                     sig,
+                     type);
     } else {
         s_fmt_map.emplace(sig, type);
     }

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -57,7 +57,7 @@ rpc_session::~rpc_session()
 
 bool rpc_session::set_connecting()
 {
-    dassert(is_client(), "must be client session");
+    CHECK(is_client(), "must be client session");
 
     utils::auto_lock<utils::ex_lock_nr> l(_lock);
     if (_connect_state == SS_DISCONNECTED) {
@@ -70,7 +70,7 @@ bool rpc_session::set_connecting()
 
 void rpc_session::set_connected()
 {
-    dassert(is_client(), "must be client session");
+    CHECK(is_client(), "must be client session");
 
     {
         utils::auto_lock<utils::ex_lock_nr> l(_lock);
@@ -261,7 +261,7 @@ void rpc_session::send_message(message_ex *msg)
         return;
     }
 
-    dassert(_parser, "parser should not be null when send");
+    CHECK(_parser, "parser should not be null when send");
     _parser->prepare_on_send(msg);
 
     uint64_t sig;
@@ -548,7 +548,7 @@ void network::on_recv_reply(uint64_t id, message_ex *msg, int delay_ms)
 message_parser *network::new_message_parser(network_header_format hdr_format)
 {
     message_parser *parser = message_parser_manager::instance().create_parser(hdr_format);
-    dassert(parser, "message parser '%s' not registerd or invalid!", hdr_format.to_string());
+    CHECK(parser, "message parser '{}' not registerd or invalid!", hdr_format);
     return parser;
 }
 
@@ -580,9 +580,8 @@ uint32_t network::get_local_ipv4()
 
     if (0 == ip) {
         char name[128];
-        if (gethostname(name, sizeof(name)) != 0) {
-            dassert(false, "gethostname failed, err = %s", strerror(errno));
-        }
+        CHECK_EQ_MSG(
+            gethostname(name, sizeof(name)), 0, "gethostname failed, err = {}", strerror(errno));
         ip = rpc_address::ipv4_from_host(name);
     }
 
@@ -608,7 +607,7 @@ void connection_oriented_network::inject_drop_message(message_ex *msg, bool is_s
         // - but if is_send == true, there may be is_session != nullptr, when it is a
         //   normal (not forwarding) reply message from server to client, in which case
         //   the io_session has also been set.
-        dassert(is_send, "received message should always has io_session set");
+        CHECK(is_send, "received message should always has io_session set");
         utils::auto_read_lock l(_clients_lock);
         auto it = _clients.find(msg->to_address);
         if (it != _clients.end()) {

--- a/src/runtime/rpc/network.sim.cpp
+++ b/src/runtime/rpc/network.sim.cpp
@@ -108,12 +108,12 @@ void sim_client_session::send(uint64_t sig)
             {
                 node_scoper ns(rnet->node());
 
-                bool ret = server_session->on_recv_message(recv_msg,
-                                                           recv_msg->to_address ==
-                                                                   recv_msg->header->from_address
-                                                               ? 0
-                                                               : rnet->net_delay_milliseconds());
-                dassert(ret, "");
+                CHECK(server_session->on_recv_message(recv_msg,
+                                                      recv_msg->to_address ==
+                                                              recv_msg->header->from_address
+                                                          ? 0
+                                                          : rnet->net_delay_milliseconds()),
+                      "");
             }
         }
     }
@@ -138,12 +138,12 @@ void sim_server_session::send(uint64_t sig)
         {
             node_scoper ns(_client->net().node());
 
-            bool ret = _client->on_recv_message(
-                recv_msg,
-                recv_msg->to_address == recv_msg->header->from_address
-                    ? 0
-                    : (static_cast<sim_network_provider *>(&_net))->net_delay_milliseconds());
-            dassert(ret, "");
+            CHECK(_client->on_recv_message(
+                      recv_msg,
+                      recv_msg->to_address == recv_msg->header->from_address
+                          ? 0
+                          : (static_cast<sim_network_provider *>(&_net))->net_delay_milliseconds()),
+                  "");
         }
     }
 

--- a/src/runtime/rpc/rpc_engine.cpp
+++ b/src/runtime/rpc/rpc_engine.cpp
@@ -634,7 +634,7 @@ void rpc_engine::call_group(rpc_address addr,
         CHECK(false, "to be implemented");
         break;
     default:
-        CHECK(false, "invalid group rpc mode {}", (int)(sp->grpc_mode));
+        CHECK(false, "invalid group rpc mode {}", sp->grpc_mode);
     }
 }
 

--- a/src/runtime/rpc/rpc_engine.cpp
+++ b/src/runtime/rpc/rpc_engine.cpp
@@ -146,7 +146,7 @@ bool rpc_client_matcher::on_recv_reply(network *net, uint64_t key, message_ex *r
             }
             break;
         default:
-            dassert(false, "not implemented");
+            CHECK(false, "not implemented");
             break;
         }
 
@@ -174,7 +174,7 @@ bool rpc_client_matcher::on_recv_reply(network *net, uint64_t key, message_ex *r
                 }
                 break;
             default:
-                dassert(false, "not implemented");
+                CHECK(false, "not implemented");
                 break;
             }
         }
@@ -303,7 +303,7 @@ void rpc_client_matcher::on_call(message_ex *request, const rpc_response_task_pt
         utils::auto_lock<::dsn::utils::ex_lock_nr_spin> l(_requests_lock[bucket_index]);
         auto pr =
             _requests[bucket_index].emplace(hdr.id, match_entry{call, timeout_task, timeout_ts_ms});
-        dassert(pr.second, "the message is already on the fly!!!");
+        CHECK(pr.second, "the message is already on the fly!!!");
     }
 
     timeout_task->set_delay(timeout_ms);
@@ -340,19 +340,19 @@ bool rpc_server_dispatcher::register_rpc_handler(dsn::task_code code,
     utils::auto_write_lock l(_handlers_lock);
     auto it = _handlers.find(code.to_string());
     auto it2 = _handlers.find(extra_name);
-    if (it == _handlers.end() && it2 == _handlers.end()) {
-        _handlers[code.to_string()] = ctx.get();
-        _handlers[ctx->extra_name] = ctx.get();
+    CHECK(it == _handlers.end() && it2 == _handlers.end(),
+          "rpc registration confliction for '{}' '{}'",
+          code,
+          extra_name);
+    _handlers[code.to_string()] = ctx.get();
+    _handlers[ctx->extra_name] = ctx.get();
 
-        {
-            utils::auto_write_lock l(_vhandlers[code.code()]->second);
-            _vhandlers[code.code()]->first = std::move(ctx);
-        }
-        return true;
-    } else {
-        dassert(false, "rpc registration confliction for '%s' '%s'", code.to_string(), extra_name);
-        return false;
+    {
+        utils::auto_write_lock l(_vhandlers[code.code()]->second);
+        _vhandlers[code.code()]->first = std::move(ctx);
     }
+    // TODO(yingchun): should return void
+    return true;
 }
 
 bool rpc_server_dispatcher::unregister_rpc_handler(dsn::task_code rpc_code)
@@ -406,7 +406,7 @@ rpc_request_task *rpc_server_dispatcher::on_request(message_ex *msg, service_nod
 //----------------------------------------------------------------------------------------------
 rpc_engine::rpc_engine(service_node *node) : _node(node), _rpc_matcher(this)
 {
-    dassert(_node != nullptr, "");
+    CHECK_NOTNULL(_node, "");
     _is_running = false;
     _is_serving = false;
 }
@@ -423,14 +423,10 @@ network *rpc_engine::create_network(const network_server_config &netcs,
     net->reset_parser_attr(client_hdr_format, netcs.message_buffer_block_size);
 
     // start the net
-    error_code ret = net->start(netcs.channel, netcs.port, client_only);
-    if (ret == ERR_OK) {
-        return net;
-    } else {
-        // mem leak, don't care as it halts the program
-        dassert(false, "create network failed, error_code: %s", ret.to_string());
-        return nullptr;
-    }
+    // If check failed, means mem leaked, don't care as it halts the program
+    CHECK_EQ_MSG(
+        net->start(netcs.channel, netcs.port, client_only), ERR_OK, "create network failed");
+    return net;
 }
 
 error_code rpc_engine::start(const service_app_spec &aspec)
@@ -635,10 +631,10 @@ void rpc_engine::call_group(rpc_address addr,
         call_ip(request->server_address.group_address()->random_member(), request, call);
         break;
     case GRPC_TO_ALL:
-        dassert(false, "to be implemented");
+        CHECK(false, "to be implemented");
         break;
     default:
-        dassert(false, "invalid group rpc mode %d", (int)(sp->grpc_mode));
+        CHECK(false, "invalid group rpc mode {}", (int)(sp->grpc_mode));
     }
 }
 
@@ -650,8 +646,8 @@ void rpc_engine::call_ip(rpc_address addr,
 {
     dbg_dassert(addr.type() == HOST_TYPE_IPV4, "only IPV4 is now supported");
     dbg_dassert(addr.port() > MAX_CLIENT_PORT, "only server address can be called");
-    dassert(!request->header->from_address.is_invalid(),
-            "from address must be set before call call_ip");
+    CHECK(!request->header->from_address.is_invalid(),
+          "from address must be set before call call_ip");
 
     while (!request->dl.is_alone()) {
         LOG_WARNING("msg request %s (trace_id = %016" PRIx64
@@ -670,20 +666,20 @@ void rpc_engine::call_ip(rpc_address addr,
     auto &hdr = *request->header;
 
     network *net = _client_nets[request->hdr_format][sp->rpc_call_channel].get();
-    dassert(nullptr != net,
-            "network not present for rpc channel '%s' with format '%s' used by rpc %s",
-            sp->rpc_call_channel.to_string(),
-            sp->rpc_call_header_format.to_string(),
-            hdr.rpc_name);
+    CHECK_NOTNULL(net,
+                  "network not present for rpc channel '{}' with format '{}' used by rpc {}",
+                  sp->rpc_call_channel,
+                  sp->rpc_call_header_format,
+                  hdr.rpc_name);
 
-    LOG_DEBUG("rpc_name = %s, remote_addr = %s, header_format = %s, channel = %s, seq_id = %" PRIu64
-              ", trace_id = %016" PRIx64,
-              hdr.rpc_name,
-              addr.to_string(),
-              request->hdr_format.to_string(),
-              sp->rpc_call_channel.to_string(),
-              hdr.id,
-              hdr.trace_id);
+    LOG_DEBUG_F("rpc_name = {}, remote_addr = {}, header_format = {}, channel = {}, seq_id = {}, "
+                "trace_id = {:#018x}",
+                hdr.rpc_name,
+                addr,
+                request->hdr_format,
+                sp->rpc_call_channel,
+                hdr.id,
+                hdr.trace_id);
 
     if (reset_request_id) {
         hdr.id = message_ex::new_id();
@@ -776,11 +772,11 @@ void rpc_engine::reply(message_ex *response, error_code err)
             // use the header format recorded in the message
             auto rpc_channel = sp ? sp->rpc_call_channel : RPC_CHANNEL_TCP;
             network *net = _client_nets[response->hdr_format][rpc_channel].get();
-            dassert(
-                nullptr != net,
-                "client network not present for rpc channel '%s' with format '%s' used by rpc %s",
-                RPC_CHANNEL_TCP.to_string(),
-                response->hdr_format.to_string(),
+            CHECK_NOTNULL(
+                net,
+                "client network not present for rpc channel '{}' with format '{}' used by rpc {}",
+                RPC_CHANNEL_TCP,
+                response->hdr_format,
                 response->header->rpc_name);
 
             if (no_fail) {
@@ -799,11 +795,11 @@ void rpc_engine::reply(message_ex *response, error_code err)
         auto rpc_channel = sp ? sp->rpc_call_channel : RPC_CHANNEL_TCP;
         network *net = _server_nets[response->header->from_address.port()][rpc_channel].get();
 
-        dassert(nullptr != net,
-                "server network not present for rpc channel '%s' on port %u used by rpc %s",
-                RPC_CHANNEL_UDP.to_string(),
-                response->header->from_address.port(),
-                response->header->rpc_name);
+        CHECK_NOTNULL(net,
+                      "server network not present for rpc channel '{}' on port {} used by rpc {}",
+                      RPC_CHANNEL_UDP,
+                      response->header->from_address.port(),
+                      response->header->rpc_name);
 
         if (no_fail) {
             net->send_message(response);
@@ -822,15 +818,16 @@ void rpc_engine::reply(message_ex *response, error_code err)
 
 void rpc_engine::forward(message_ex *request, rpc_address address)
 {
-    dassert(request->header->context.u.is_request, "only rpc request can be forwarded");
-    dassert(request->header->context.u.is_forward_supported,
-            "rpc msg %s (trace_id = %016" PRIx64 ") does not support being forwared",
-            task_spec::get(request->local_rpc_code)->name.c_str(),
-            request->header->trace_id);
-    dassert(address != primary_address(),
-            "cannot forward msg %s (trace_id = %016" PRIx64 ") to the local node",
-            task_spec::get(request->local_rpc_code)->name.c_str(),
-            request->header->trace_id);
+    CHECK(request->header->context.u.is_request, "only rpc request can be forwarded");
+    CHECK(request->header->context.u.is_forward_supported,
+          "rpc msg {} (trace_id = {:#018x}) does not support being forwared",
+          task_spec::get(request->local_rpc_code)->name,
+          request->header->trace_id);
+    CHECK_NE_MSG(address,
+                 primary_address(),
+                 "cannot forward msg {} (trace_id = {:#018x}) to the local node",
+                 task_spec::get(request->local_rpc_code)->name,
+                 request->header->trace_id);
 
     // msg is from pure client (no server port assigned)
     // in this case, we have no way to directly post a message

--- a/src/runtime/rpc/rpc_engine.h
+++ b/src/runtime/rpc/rpc_engine.h
@@ -206,7 +206,7 @@ rpc_engine::call_address(rpc_address addr, message_ex *request, const rpc_respon
         call_group(addr, request, call);
         break;
     default:
-        CHECK(false, "invalid target address type {}", (int)request->server_address.type());
+        CHECK(false, "invalid target address type {}", request->server_address.type());
         break;
     }
 }

--- a/src/runtime/rpc/rpc_engine.h
+++ b/src/runtime/rpc/rpc_engine.h
@@ -206,7 +206,7 @@ rpc_engine::call_address(rpc_address addr, message_ex *request, const rpc_respon
         call_group(addr, request, call);
         break;
     default:
-        dassert(false, "invalid target address type %d", (int)request->server_address.type());
+        CHECK(false, "invalid target address type {}", (int)request->server_address.type());
         break;
     }
 }

--- a/src/runtime/rpc/rpc_holder.h
+++ b/src/runtime/rpc/rpc_holder.h
@@ -111,31 +111,31 @@ public:
 
     const TRequest &request() const
     {
-        dassert(_i, "rpc_holder is uninitialized");
+        CHECK(_i, "rpc_holder is uninitialized");
         return *(_i->thrift_request);
     }
 
     TRequest *mutable_request() const
     {
-        dassert(_i, "rpc_holder is uninitialized");
+        CHECK(_i, "rpc_holder is uninitialized");
         return _i->thrift_request.get();
     }
 
     TResponse &response() const
     {
-        dassert(_i, "rpc_holder is uninitialized");
+        CHECK(_i, "rpc_holder is uninitialized");
         return _i->thrift_response;
     }
 
     dsn::error_code &error() const
     {
-        dassert(_i, "rpc_holder is uninitialized");
+        CHECK(_i, "rpc_holder is uninitialized");
         return _i->rpc_error;
     }
 
     message_ex *dsn_request() const
     {
-        dassert(_i, "rpc_holder is uninitialized");
+        CHECK(_i, "rpc_holder is uninitialized");
         return _i->dsn_request;
     }
 
@@ -257,13 +257,13 @@ public:
 
     static mail_box_t &mail_box()
     {
-        dassert(_mail_box != nullptr, "call this function only when you are in mock mode");
+        CHECK_NOTNULL(_mail_box, "call this function only when you are in mock mode");
         return *_mail_box.get();
     }
 
     static mail_box_t &forward_mail_box()
     {
-        dassert(_forward_mail_box != nullptr, "call this function only when you are in mock mode");
+        CHECK_NOTNULL(_forward_mail_box, "call this function only when you are in mock mode");
         return *_forward_mail_box.get();
     }
 
@@ -290,7 +290,7 @@ private:
                  int thread_hash)
             : thrift_request(std::move(req)), auto_reply(false)
         {
-            dassert(thrift_request != nullptr, "req should not be null");
+            CHECK_NOTNULL(thrift_request, "req should not be null");
 
             dsn_request = message_ex::create_request(
                 code, static_cast<int>(timeout.count()), thread_hash, partition_hash);

--- a/src/runtime/rpc/rpc_holder.h
+++ b/src/runtime/rpc/rpc_holder.h
@@ -257,13 +257,13 @@ public:
 
     static mail_box_t &mail_box()
     {
-        CHECK_NOTNULL(_mail_box, "call this function only when you are in mock mode");
+        CHECK(_mail_box, "call this function only when you are in mock mode");
         return *_mail_box.get();
     }
 
     static mail_box_t &forward_mail_box()
     {
-        CHECK_NOTNULL(_forward_mail_box, "call this function only when you are in mock mode");
+        CHECK(_forward_mail_box, "call this function only when you are in mock mode");
         return *_forward_mail_box.get();
     }
 
@@ -290,7 +290,7 @@ private:
                  int thread_hash)
             : thrift_request(std::move(req)), auto_reply(false)
         {
-            CHECK_NOTNULL(thrift_request, "req should not be null");
+            CHECK(thrift_request, "req should not be null");
 
             dsn_request = message_ex::create_request(
                 code, static_cast<int>(timeout.count()), thread_hash, partition_hash);

--- a/src/runtime/rpc/rpc_stream.h
+++ b/src/runtime/rpc/rpc_stream.h
@@ -56,9 +56,8 @@ public:
         _msg = msg;
         if (nullptr != _msg) {
             ::dsn::blob bb;
-            bool r = ((::dsn::message_ex *)_msg)->read_next(bb);
-            dassert(r, "read msg must have one segment of buffer ready");
-
+            CHECK(((::dsn::message_ex *)_msg)->read_next(bb),
+                  "read msg must have one segment of buffer ready");
             init(std::move(bb));
         }
     }

--- a/src/runtime/rpc/serialization.h
+++ b/src/runtime/rpc/serialization.h
@@ -61,7 +61,7 @@ inline void marshall(binary_writer &writer, const ThriftType &value, dsn_msg_ser
         marshall_thrift_json(writer, value);
         break;
     default:
-        dassert(false, serialization::no_registered_function_error_notice(value, fmt).c_str());
+        CHECK(false, serialization::no_registered_function_error_notice(value, fmt));
     }
 }
 
@@ -76,7 +76,7 @@ inline void unmarshall(binary_reader &reader, ThriftType &value, dsn_msg_seriali
         unmarshall_thrift_json(reader, value);
         break;
     default:
-        dassert(false, serialization::no_registered_function_error_notice(value, fmt).c_str());
+        CHECK(false, serialization::no_registered_function_error_notice(value, fmt));
     }
 }
 

--- a/src/runtime/rpc/thrift_message_parser.cpp
+++ b/src/runtime/rpc/thrift_message_parser.cpp
@@ -318,9 +318,9 @@ void thrift_message_parser::prepare_on_send(message_ex *msg)
     auto &header = msg->header;
     auto &buffers = msg->buffers;
 
-    dassert(!header->context.u.is_request, "only support send response");
-    dassert(header->server.error_name[0], "error name should be set");
-    dassert(!buffers.empty(), "buffers can not be empty");
+    CHECK(!header->context.u.is_request, "only support send response");
+    CHECK(header->server.error_name[0], "error name should be set");
+    CHECK(!buffers.empty(), "buffers can not be empty");
 
     // write thrift response header and thrift message begin
     binary_writer header_writer;

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -285,7 +285,7 @@ void scheduler::schedule()
 
                     t->release_ref(); // added by previous t->enqueue from app
                 } else {
-                    dassert(e.system_task != nullptr, "app and system tasks cannot be both empty");
+                    CHECK_NOTNULL(e.system_task, "app and system tasks cannot be both empty");
                     e.system_task();
                 }
             }

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -285,7 +285,7 @@ void scheduler::schedule()
 
                     t->release_ref(); // added by previous t->enqueue from app
                 } else {
-                    CHECK_NOTNULL(e.system_task, "app and system tasks cannot be both empty");
+                    CHECK(e.system_task, "app and system tasks cannot be both empty");
                     e.system_task();
                 }
             }

--- a/src/runtime/security/meta_access_controller.cpp
+++ b/src/runtime/security/meta_access_controller.cpp
@@ -59,9 +59,10 @@ bool meta_access_controller::allowed(message_ex *msg)
 void meta_access_controller::register_allowed_list(const std::string &rpc_code)
 {
     auto code = task_code::try_get(rpc_code, TASK_CODE_INVALID);
-    dassert_f(code != TASK_CODE_INVALID,
-              "invalid task code({}) in rpc_code_white_list of security section",
-              rpc_code);
+    CHECK_NE_MSG(code,
+                 TASK_CODE_INVALID,
+                 "invalid task code({}) in rpc_code_white_list of security section",
+                 rpc_code);
 
     _allowed_rpc_code_list.insert(code);
 }

--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -396,11 +396,11 @@ bool run(const char *config_file,
     // setup data dir
     auto &data_dir = spec.data_dir;
     CHECK(!dsn::utils::filesystem::file_exists(data_dir), "{} should not be a file.", data_dir);
-    if (!dsn::utils::filesystem::directory_exists(data_dir.c_str())) {
+    if (!dsn::utils::filesystem::directory_exists(data_dir)) {
         CHECK(dsn::utils::filesystem::create_directory(data_dir), "Fail to create {}", data_dir);
     }
     std::string cdir;
-    CHECK(dsn::utils::filesystem::get_absolute_path(data_dir.c_str(), cdir),
+    CHECK(dsn::utils::filesystem::get_absolute_path(data_dir, cdir),
           "Fail to get absolute path from {}",
           data_dir);
     spec.data_dir = cdir;
@@ -447,7 +447,7 @@ bool run(const char *config_file,
     for (auto it = spec.toollets.begin(); it != spec.toollets.end(); ++it) {
         auto tlet =
             dsn::tools::internal_use_only::get_toollet(it->c_str(), ::dsn::PROVIDER_TYPE_MAIN);
-        CHECK(tlet, "toolet not found");
+        CHECK_NOTNULL(tlet, "toolet not found");
         tlet->install(spec);
     }
 

--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -395,18 +395,14 @@ bool run(const char *config_file,
 
     // setup data dir
     auto &data_dir = spec.data_dir;
-    dassert(!dsn::utils::filesystem::file_exists(data_dir),
-            "%s should not be a file.",
-            data_dir.c_str());
+    CHECK(!dsn::utils::filesystem::file_exists(data_dir), "{} should not be a file.", data_dir);
     if (!dsn::utils::filesystem::directory_exists(data_dir.c_str())) {
-        if (!dsn::utils::filesystem::create_directory(data_dir)) {
-            dassert(false, "Fail to create %s.", data_dir.c_str());
-        }
+        CHECK(dsn::utils::filesystem::create_directory(data_dir), "Fail to create {}", data_dir);
     }
     std::string cdir;
-    if (!dsn::utils::filesystem::get_absolute_path(data_dir.c_str(), cdir)) {
-        dassert(false, "Fail to get absolute path from %s.", data_dir.c_str());
-    }
+    CHECK(dsn::utils::filesystem::get_absolute_path(data_dir.c_str(), cdir),
+          "Fail to get absolute path from {}",
+          data_dir);
     spec.data_dir = cdir;
 
     ::dsn::utils::coredump::init();
@@ -451,7 +447,7 @@ bool run(const char *config_file,
     for (auto it = spec.toollets.begin(); it != spec.toollets.end(); ++it) {
         auto tlet =
             dsn::tools::internal_use_only::get_toollet(it->c_str(), ::dsn::PROVIDER_TYPE_MAIN);
-        dassert(tlet, "toolet not found");
+        CHECK(tlet, "toolet not found");
         tlet->install(spec);
     }
 

--- a/src/runtime/service_app.h
+++ b/src/runtime/service_app.h
@@ -94,7 +94,7 @@ public:
     virtual error_code stop(bool cleanup = false) { return ERR_OK; }
     virtual void on_intercepted_request(gpid pid, bool is_write, dsn::message_ex *msg)
     {
-        dassert(false, "not supported");
+        CHECK(false, "not supported");
     }
 
     bool is_started() const { return _started; }

--- a/src/runtime/service_engine.cpp
+++ b/src/runtime/service_engine.cpp
@@ -65,7 +65,7 @@ error_code service_node::init_rpc_engine()
 
 dsn::error_code service_node::start_app()
 {
-    dassert(_entity.get(), "entity hasn't initialized");
+    CHECK(_entity, "entity hasn't initialized");
     _entity->set_address(rpc()->primary_address());
 
     std::vector<std::string> args;
@@ -80,7 +80,7 @@ dsn::error_code service_node::start_app()
 
 dsn::error_code service_node::stop_app(bool cleanup)
 {
-    dassert(_entity.get(), "entity hasn't initialized");
+    CHECK(_entity, "entity hasn't initialized");
     dsn::error_code res = _entity->stop(cleanup);
     if (res == dsn::ERR_OK) {
         _entity->set_started(false);
@@ -111,7 +111,7 @@ error_code service_node::start()
     // init task engine
     _computation = make_unique<task_engine>(this);
     _computation->create(_app_spec.pools);
-    dassert(!_computation->is_started(), "task engine must not be started at this point");
+    CHECK(!_computation->is_started(), "task engine must not be started at this point");
 
     // init rpc
     err = init_rpc_engine();
@@ -120,7 +120,7 @@ error_code service_node::start()
 
     // start task engine
     _computation->start();
-    dassert(_computation->is_started(), "task engine must be started at this point");
+    CHECK(_computation->is_started(), "task engine must be started at this point");
 
     // create service_app
     {

--- a/src/runtime/task/simple_task_queue.cpp
+++ b/src/runtime/task/simple_task_queue.cpp
@@ -52,7 +52,7 @@ void simple_timer_service::start()
         boost::asio::io_service::work work(_ios);
         boost::system::error_code ec;
         _ios.run(ec);
-        CHECK(!ec, "io_service in simple_timer_service run failed: {}", ec.message().data());
+        CHECK(!ec, "io_service in simple_timer_service run failed: {}", ec.message());
     });
     _is_running = true;
 }

--- a/src/runtime/task/simple_task_queue.cpp
+++ b/src/runtime/task/simple_task_queue.cpp
@@ -52,10 +52,7 @@ void simple_timer_service::start()
         boost::asio::io_service::work work(_ios);
         boost::system::error_code ec;
         _ios.run(ec);
-        if (ec) {
-            dassert(
-                false, "io_service in simple_timer_service run failed: %s", ec.message().data());
-        }
+        CHECK(!ec, "io_service in simple_timer_service run failed: {}", ec.message().data());
     });
     _is_running = true;
 }
@@ -101,7 +98,7 @@ task *simple_task_queue::dequeue(/*inout*/ int &batch_size)
 {
     long c = 0;
     auto t = _samples.dequeue(c);
-    dassert(t != nullptr, "dequeue does not return empty tasks");
+    CHECK_NOTNULL(t, "dequeue does not return empty tasks");
     batch_size = 1;
     return t;
 }

--- a/src/runtime/task/task.cpp
+++ b/src/runtime/task/task.cpp
@@ -87,21 +87,18 @@ __thread uint16_t tls_dsn_lower32_task_id_mask = 0;
 
 /*static*/ void task::on_tls_dsn_not_set()
 {
-    if (service_engine::instance().spec().enable_default_app_mimic) {
-        dsn_mimic_app("mimic", 1);
-    } else {
-        CHECK(false,
-              "rDSN context is not initialized properly, to be fixed as follows:\n"
-              "(1). the current thread does NOT belongs to any rDSN service node, please invoke "
-              "dsn_mimic_app first,\n"
-              "     or, you can enable [core] enable_default_app_mimic = true in your config "
-              "file so mimic_app can be omitted\n"
-              "(2). the current thread belongs to a rDSN service node, and you are writing "
-              "providers for rDSN, please use\n"
-              "     task::set_tls_dsn_context(...) at the beginning of your new thread in your "
-              "providers;\n"
-              "(3). this should not happen, please help fire an issue so we we can investigate");
-    }
+    CHECK(service_engine::instance().spec().enable_default_app_mimic,
+          "rDSN context is not initialized properly, to be fixed as follows:\n"
+          "(1). the current thread does NOT belongs to any rDSN service node, please invoke "
+          "dsn_mimic_app first,\n"
+          "     or, you can enable [core] enable_default_app_mimic = true in your config "
+          "file so mimic_app can be omitted\n"
+          "(2). the current thread belongs to a rDSN service node, and you are writing "
+          "providers for rDSN, please use\n"
+          "     task::set_tls_dsn_context(...) at the beginning of your new thread in your "
+          "providers;\n"
+          "(3). this should not happen, please help fire an issue so we we can investigate");
+    dsn_mimic_app("mimic", 1);
 }
 
 task::task(dsn::task_code code, int hash, service_node *node)

--- a/src/runtime/task/task.cpp
+++ b/src/runtime/task/task.cpp
@@ -90,17 +90,17 @@ __thread uint16_t tls_dsn_lower32_task_id_mask = 0;
     if (service_engine::instance().spec().enable_default_app_mimic) {
         dsn_mimic_app("mimic", 1);
     } else {
-        dassert(false,
-                "rDSN context is not initialized properly, to be fixed as follows:\n"
-                "(1). the current thread does NOT belongs to any rDSN service node, please invoke "
-                "dsn_mimic_app first,\n"
-                "     or, you can enable [core] enable_default_app_mimic = true in your config "
-                "file so mimic_app can be omitted\n"
-                "(2). the current thread belongs to a rDSN service node, and you are writing "
-                "providers for rDSN, please use\n"
-                "     task::set_tls_dsn_context(...) at the beginning of your new thread in your "
-                "providers;\n"
-                "(3). this should not happen, please help fire an issue so we we can investigate");
+        CHECK(false,
+              "rDSN context is not initialized properly, to be fixed as follows:\n"
+              "(1). the current thread does NOT belongs to any rDSN service node, please invoke "
+              "dsn_mimic_app first,\n"
+              "     or, you can enable [core] enable_default_app_mimic = true in your config "
+              "file so mimic_app can be omitted\n"
+              "(2). the current thread belongs to a rDSN service node, and you are writing "
+              "providers for rDSN, please use\n"
+              "     task::set_tls_dsn_context(...) at the beginning of your new thread in your "
+              "providers;\n"
+              "(3). this should not happen, please help fire an issue so we we can investigate");
     }
 }
 
@@ -118,9 +118,9 @@ task::task(dsn::task_code code, int hash, service_node *node)
         _node = node;
     } else {
         auto p = get_current_node();
-        dassert(p != nullptr,
-                "tasks without explicit service node "
-                "can only be created inside threads which is attached to specific node");
+        CHECK_NOTNULL(p,
+                      "tasks without explicit service node "
+                      "can only be created inside threads which is attached to specific node");
         _node = p;
     }
 
@@ -270,7 +270,7 @@ bool task::wait_on_cancel()
 
 bool task::wait(int timeout_milliseconds)
 {
-    dassert(this != task::get_current_task(), "task cannot wait itself");
+    CHECK(this != task::get_current_task(), "task cannot wait itself");
 
     auto cs = state();
 
@@ -325,9 +325,8 @@ bool task::cancel(bool wait_until_finished, /*out*/ bool *finished /*= nullptr*/
                 finish = true;
             } else if (wait_until_finished) {
                 _wait_for_cancel = true;
-                bool r = wait_on_cancel();
-                dassert(
-                    r,
+                CHECK(
+                    wait_on_cancel(),
                     "wait failed, it is only possible when task runs for more than 0x0fffffff ms");
 
                 succ = false;
@@ -372,10 +371,11 @@ const char *task::get_current_node_name()
 
 void task::enqueue()
 {
-    dassert(_node != nullptr, "service node unknown for this task");
-    dassert(_spec->type != TASK_TYPE_RPC_RESPONSE,
-            "tasks with TASK_TYPE_RPC_RESPONSE type use task::enqueue(caller_pool()) instead");
-    dassert(_error != ERR_IO_PENDING, "task is waiting for IO, can not be enqueue");
+    CHECK_NOTNULL(_node, "service node unknown for this task");
+    CHECK_NE_MSG(_spec->type,
+                 TASK_TYPE_RPC_RESPONSE,
+                 "tasks with TASK_TYPE_RPC_RESPONSE type use task::enqueue(caller_pool()) instead");
+    CHECK_NE_MSG(_error, ERR_IO_PENDING, "task is waiting for IO, can not be enqueue");
 
     auto pool = node()->computation()->get_pool(spec().pool_code);
     enqueue(pool);
@@ -385,14 +385,14 @@ void task::enqueue(task_worker_pool *pool)
 {
     this->add_ref(); // released in exec_internal (even when cancelled)
 
-    dassert(pool != nullptr,
-            "pool %s not ready, and there are usually two cases: "
-            "(1). thread pool not designatd in '[%s] pools'; "
-            "(2). the caller is executed in io threads "
-            "which is forbidden unless you explicitly set [task.%s].allow_inline = true",
-            _spec->pool_code.to_string(),
-            _node->spec().config_section.c_str(),
-            _spec->name.c_str());
+    CHECK_NOTNULL(pool,
+                  "pool {} not ready, and there are usually two cases: "
+                  "(1). thread pool not designatd in '[{}] pools'; "
+                  "(2). the caller is executed in io threads "
+                  "which is forbidden unless you explicitly set [task.{}].allow_inline = true",
+                  _spec->pool_code,
+                  _node->spec().config_section,
+                  _spec->name);
 
     if (spec().type == TASK_TYPE_COMPUTE) {
         spec().on_task_enqueue.execute(get_current_task(), this);
@@ -440,20 +440,22 @@ timer_task::timer_task(
     task_code code, const task_handler &cb, int interval_milliseconds, int hash, service_node *node)
     : task(code, hash, node), _interval_milliseconds(interval_milliseconds), _cb(cb)
 {
-    dassert(
-        TASK_TYPE_COMPUTE == spec().type,
-        "%s is not a computation type task, please use DEFINE_TASK_CODE to define the task code",
-        spec().name.c_str());
+    CHECK_EQ_MSG(
+        TASK_TYPE_COMPUTE,
+        spec().type,
+        "{} is not a computation type task, please use DEFINE_TASK_CODE to define the task code",
+        spec().name);
 }
 
 timer_task::timer_task(
     task_code code, task_handler &&cb, int interval_milliseconds, int hash, service_node *node)
     : task(code, hash, node), _interval_milliseconds(interval_milliseconds), _cb(std::move(cb))
 {
-    dassert(
-        TASK_TYPE_COMPUTE == spec().type,
-        "%s is not a computation type task, please use DEFINE_TASK_CODE to define the task code",
-        spec().name.c_str());
+    CHECK_EQ_MSG(
+        TASK_TYPE_COMPUTE,
+        spec().type,
+        "{} is not a computation type task, please use DEFINE_TASK_CODE to define the task code",
+        spec().name);
 }
 
 void timer_task::enqueue()
@@ -473,9 +475,9 @@ void timer_task::exec()
     }
     // valid interval, we reset task state to READY
     if (dsn_likely(_interval_milliseconds > 0)) {
-        dassert(set_retry(true),
-                "timer task set retry failed, with state = %s",
-                enum_to_string(state()));
+        CHECK(set_retry(true),
+              "timer task set retry failed, with state = {}",
+              enum_to_string(state()));
         set_delay(_interval_milliseconds);
     }
 }

--- a/src/runtime/task/task_engine.sim.cpp
+++ b/src/runtime/task/task_engine.sim.cpp
@@ -205,7 +205,7 @@ void sim_lock_nr_provider::lock()
         return;
 
     int ctid = ::dsn::utils::get_current_tid();
-    dassert(ctid != _current_holder, "non-recursive lock, error or use recursive locks instead");
+    CHECK_NE_MSG(ctid, _current_holder, "non-recursive lock, error or use recursive locks instead");
 
     _sema.wait(TIME_MS_MAX);
 
@@ -221,7 +221,7 @@ bool sim_lock_nr_provider::try_lock()
         return true;
 
     int ctid = ::dsn::utils::get_current_tid();
-    dassert(ctid != _current_holder, "non-recursive lock, error or use recursive locks instead");
+    CHECK_NE_MSG(ctid, _current_holder, "non-recursive lock, error or use recursive locks instead");
 
     bool r = _sema.wait(0);
     if (r) {
@@ -242,12 +242,9 @@ void sim_lock_nr_provider::unlock()
                  _current_holder,
                  "lock must be locked must current holder");
 
-    if (0 == --_lock_depth) {
-        _current_holder = -1;
-        _sema.signal(1);
-    } else {
-        dassert(false, "non-recursive lock, error or use recursive locks instead");
-    }
+    CHECK_EQ_MSG(0, --_lock_depth, "non-recursive lock, error or use recursive locks instead");
+    _current_holder = -1;
+    _sema.signal(1);
 }
 }
 } // end namespace

--- a/src/runtime/task/task_spec.cpp
+++ b/src/runtime/task/task_spec.cpp
@@ -70,15 +70,13 @@ void task_spec::register_task_code(task_code code,
         }
     } else {
         auto spec = task_spec::get(code);
-        if (spec->type != type) {
-            dassert(
-                false,
-                "task code %s registerd for %s, which does not match with previously registered %s",
-                code.to_string(),
-                enum_to_string(type),
-                enum_to_string(spec->type));
-            return;
-        }
+        CHECK_EQ_MSG(
+            spec->type,
+            type,
+            "task code {} registerd for {}, which does not match with previously registered {}",
+            code,
+            enum_to_string(type),
+            enum_to_string(spec->type));
 
         if (spec->priority != pri) {
             LOG_WARNING("overwrite priority for task %s from %s to %s",
@@ -202,7 +200,7 @@ bool task_spec::init()
         std::string section_name =
             std::string("task.") + std::string(dsn::task_code(code).to_string());
         task_spec *spec = task_spec::get(code);
-        dassert(spec != nullptr, "task_spec cannot be null");
+        CHECK_NOTNULL(spec, "");
 
         if (!read_config(section_name.c_str(), *spec, &default_spec))
             return false;

--- a/src/runtime/tracer.cpp
+++ b/src/runtime/tracer.cpp
@@ -299,7 +299,7 @@ void tracer::install(service_spec &spec)
         std::string section_name =
             std::string("task.") + std::string(dsn::task_code(i).to_string());
         task_spec *spec = task_spec::get(i);
-        dassert(spec != nullptr, "task_spec cannot be null");
+        CHECK_NOTNULL(spec, "");
 
         if (!dsn_config_get_value_bool(
                 section_name.c_str(), "is_trace", trace, "whether to trace this kind of task"))

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1731,8 +1731,7 @@ dsn::error_code pegasus_server_impl::start(int argc, char **argv)
     static std::once_flag flag;
     std::call_once(flag, [&]() {
         // The timer task will always running even though there is no replicas
-        dassert_f(kServerStatUpdateTimeSec.count() != 0,
-                  "kServerStatUpdateTimeSec shouldn't be zero");
+        CHECK_NE(kServerStatUpdateTimeSec.count(), 0);
         _update_server_rdb_stat = dsn::tasking::enqueue_timer(
             LPC_REPLICATION_LONG_COMMON,
             nullptr, // TODO: the tracker is nullptr, we will fix it later

--- a/src/server/pegasus_server_impl_init.cpp
+++ b/src/server/pegasus_server_impl_init.cpp
@@ -451,9 +451,9 @@ pegasus_server_impl::pegasus_server_impl(dsn::replication::replica *r)
                                     "binary_search",
                                     "The index type that will be used for this table.");
     auto index_type_item = INDEX_TYPE_STRING_MAP.find(index_type);
-    dassert(index_type_item != INDEX_TYPE_STRING_MAP.end(),
-            "[pegasus.server]rocksdb_index_type should be one among binary_search, "
-            "hash_search, two_level_index_search or binary_search_with_first_key.");
+    CHECK(index_type_item != INDEX_TYPE_STRING_MAP.end(),
+          "[pegasus.server]rocksdb_index_type should be one among binary_search, "
+          "hash_search, two_level_index_search or binary_search_with_first_key.");
     tbl_opts.index_type = index_type_item->second;
     LOG_INFO_PREFIX("rocksdb_index_type = {}", index_type.c_str());
 

--- a/src/server/pegasus_write_service.cpp
+++ b/src/server/pegasus_write_service.cpp
@@ -244,7 +244,7 @@ int pegasus_write_service::batch_put(const db_write_context &ctx,
                                      const dsn::apps::update_request &update,
                                      dsn::apps::update_response &resp)
 {
-    dassert(_batch_start_time != 0, "batch_put must be called after batch_prepare");
+    CHECK_GT_MSG(_batch_start_time, 0, "batch_put must be called after batch_prepare");
 
     _batch_qps_perfcounters.push_back(_pfc_put_qps.get());
     _batch_latency_perfcounters.push_back(_pfc_put_latency.get());
@@ -261,7 +261,7 @@ int pegasus_write_service::batch_remove(int64_t decree,
                                         const dsn::blob &key,
                                         dsn::apps::update_response &resp)
 {
-    dassert(_batch_start_time != 0, "batch_remove must be called after batch_prepare");
+    CHECK_GT_MSG(_batch_start_time, 0, "batch_remove must be called after batch_prepare");
 
     _batch_qps_perfcounters.push_back(_pfc_remove_qps.get());
     _batch_latency_perfcounters.push_back(_pfc_remove_latency.get());
@@ -276,7 +276,7 @@ int pegasus_write_service::batch_remove(int64_t decree,
 
 int pegasus_write_service::batch_commit(int64_t decree)
 {
-    dassert(_batch_start_time != 0, "batch_commit must be called after batch_prepare");
+    CHECK_GT_MSG(_batch_start_time, 0, "batch_commit must be called after batch_prepare");
 
     int err = _impl->batch_commit(decree);
     clear_up_batch_states();
@@ -285,7 +285,7 @@ int pegasus_write_service::batch_commit(int64_t decree)
 
 void pegasus_write_service::batch_abort(int64_t decree, int err)
 {
-    dassert(_batch_start_time != 0, "batch_abort must be called after batch_prepare");
+    CHECK_GT_MSG(_batch_start_time, 0, "batch_abort must be called after batch_prepare");
     CHECK(err, "must abort on non-zero err");
 
     _impl->batch_abort(decree, err);

--- a/src/server/rocksdb_wrapper.cpp
+++ b/src/server/rocksdb_wrapper.cpp
@@ -138,7 +138,7 @@ int rocksdb_wrapper::write_batch_put_ctx(const db_write_context &ctx,
 
 int rocksdb_wrapper::write(int64_t decree)
 {
-    dassert(_write_batch->Count() != 0, "the number of updates in the batch is 0");
+    CHECK_GT(_write_batch->Count(), 0);
 
     FAIL_POINT_INJECT_F("db_write", [](dsn::string_view) -> int { return FAIL_DB_WRITE; });
 

--- a/src/shell/commands/data_operations.cpp
+++ b/src/shell/commands/data_operations.cpp
@@ -63,7 +63,7 @@ bool data_operations(command_executor *e, shell_context *sc, arguments args)
     }
 
     auto iter = data_operations_map.find(args.argv[0]);
-    dassert(iter != data_operations_map.end(), "filter should done earlier");
+    CHECK(iter != data_operations_map.end(), "filter should done earlier");
     executor func = iter->second;
 
     if (sc->current_app_name.empty()) {

--- a/src/utils/api_utilities.h
+++ b/src/utils/api_utilities.h
@@ -92,15 +92,6 @@ extern DSN_API void dsn_coredump();
 #define LOG_ERROR(...) dlog(LOG_LEVEL_ERROR, __VA_ARGS__)
 #define LOG_FATAL(...) dlog(LOG_LEVEL_FATAL, __VA_ARGS__)
 
-#define dassert(x, ...)                                                                            \
-    do {                                                                                           \
-        if (dsn_unlikely(!(x))) {                                                                  \
-            dlog(LOG_LEVEL_FATAL, "assertion expression: " #x);                                    \
-            dlog(LOG_LEVEL_FATAL, __VA_ARGS__);                                                    \
-            dsn_coredump();                                                                        \
-        }                                                                                          \
-    } while (false)
-
 #define dreturn_not_ok_logged(err, ...)                                                            \
     do {                                                                                           \
         if (dsn_unlikely((err) != dsn::ERR_OK)) {                                                  \
@@ -108,12 +99,6 @@ extern DSN_API void dsn_coredump();
             return err;                                                                            \
         }                                                                                          \
     } while (0)
-
-#ifndef NDEBUG
-#define dbg_dassert dassert
-#else
-#define dbg_dassert(x, ...)
-#endif
 
 #ifdef DSN_MOCK_TEST
 #define mock_private public

--- a/src/utils/command_manager.cpp
+++ b/src/utils/command_manager.cpp
@@ -49,7 +49,7 @@ dsn_handle_t command_manager::register_command(const std::vector<std::string> &c
             CHECK(it == _handlers.end(), "command '{}' already regisered", cmd);
         }
     }
-    dassert(is_valid_cmd, "should not register empty command");
+    CHECK(is_valid_cmd, "should not register empty command");
 
     command_instance *c = new command_instance();
     c->commands = commands;
@@ -68,7 +68,7 @@ dsn_handle_t command_manager::register_command(const std::vector<std::string> &c
 void command_manager::deregister_command(dsn_handle_t handle)
 {
     auto c = reinterpret_cast<command_instance *>(handle);
-    dassert(c != nullptr, "cannot deregister a null handle");
+    CHECK_NOTNULL(c, "cannot deregister a null handle");
     utils::auto_write_lock l(_lock);
     for (const std::string &cmd : c->commands) {
         _handlers.erase(cmd);

--- a/src/utils/errors.h
+++ b/src/utils/errors.h
@@ -195,13 +195,13 @@ public:
 
     const T &get_value() const
     {
-        CHECK(_err.is_ok(), get_error().description().data());
+        CHECK(_err.is_ok(), get_error().description());
         return *_value;
     }
 
     T &get_value()
     {
-        CHECK(_err.is_ok(), get_error().description().data());
+        CHECK(_err.is_ok(), get_error().description());
         return *_value;
     }
 

--- a/src/utils/errors.h
+++ b/src/utils/errors.h
@@ -26,12 +26,13 @@
 
 #pragma once
 
+#include <sstream>
+
+#include "utils/api_utilities.h"
 #include "utils/error_code.h"
+#include "utils/fmt_logging.h"
 #include "utils/smart_pointers.h"
 #include "utils/string_view.h"
-#include "utils/api_utilities.h"
-
-#include <sstream>
 
 namespace dsn {
 
@@ -194,13 +195,13 @@ public:
 
     const T &get_value() const
     {
-        dassert(_err.is_ok(), "%s", get_error().description().data());
+        CHECK(_err.is_ok(), get_error().description().data());
         return *_value;
     }
 
     T &get_value()
     {
-        dassert(_err.is_ok(), "%s", get_error().description().data());
+        CHECK(_err.is_ok(), get_error().description().data());
         return *_value;
     }
 

--- a/src/utils/filesystem.cpp
+++ b/src/utils/filesystem.cpp
@@ -121,7 +121,7 @@ int get_normalized_path(const std::string &path, std::string &npath)
         tls_path_buffer[pos - 1] = _FS_NULL;
     }
 
-    dassert(tls_path_buffer[0] != _FS_NULL, "Normalized path cannot be empty!");
+    CHECK_NE_MSG(tls_path_buffer[0], _FS_NULL, "Normalized path cannot be empty!");
     npath = tls_path_buffer;
 
     return 0;

--- a/src/utils/flags.cpp
+++ b/src/utils/flags.cpp
@@ -265,7 +265,7 @@ public:
     void add_validator(const char *name, validator_fn &validator)
     {
         auto it = _flags.find(name);
-        dassert(it != _flags.end(), "flag \"%s\" does not exist", name);
+        CHECK(it != _flags.end(), "flag '{}' does not exist", name);
         flag_data &flag = it->second;
         if (!flag.validator()) {
             flag.set_validator(validator);
@@ -274,9 +274,9 @@ public:
 
     void add_group_validator(const char *name, group_validator_fn &validator)
     {
-        auto it = _group_flag_validators.find(name);
-        dassert_f(
-            it == _group_flag_validators.end(), "duplicate group flag validator \"{}\"", name);
+        CHECK(_group_flag_validators.find(name) == _group_flag_validators.end(),
+              "duplicate group flag validator '{}'",
+              name);
         _group_flag_validators[name] = validator;
     }
 
@@ -296,7 +296,7 @@ public:
     void add_tag(const char *name, const flag_tag &tag)
     {
         auto it = _flags.find(name);
-        dassert(it != _flags.end(), "flag \"%s\" does not exist", name);
+        CHECK(it != _flags.end(), "flag '{}' does not exist", name);
         it->second.add_tag(tag);
     }
 

--- a/src/utils/fmt_logging.h
+++ b/src/utils/fmt_logging.h
@@ -37,7 +37,8 @@
 #define LOG_WARNING_F(...) dlog_f(LOG_LEVEL_WARNING, __VA_ARGS__)
 #define LOG_ERROR_F(...) dlog_f(LOG_LEVEL_ERROR, __VA_ARGS__)
 #define LOG_FATAL_F(...) dlog_f(LOG_LEVEL_FATAL, __VA_ARGS__)
-#define dassert_f(x, ...)                                                                          \
+
+#define CHECK(x, ...)                                                                              \
     do {                                                                                           \
         if (dsn_unlikely(!(x))) {                                                                  \
             dlog_f(LOG_LEVEL_FATAL, "assertion expression: " #x);                                  \
@@ -46,7 +47,13 @@
         }                                                                                          \
     } while (false)
 
-#define CHECK dassert_f
+// TODO(yingchun): use DCHECK instead of dbg_dassert
+#ifndef NDEBUG
+#define dbg_dassert CHECK
+#else
+#define dbg_dassert(x, ...)
+#endif
+
 #define CHECK_NOTNULL(p, ...) CHECK(p != nullptr, __VA_ARGS__)
 
 // Macros for writing log message prefixed by log_prefix().

--- a/src/utils/logging.cpp
+++ b/src/utils/logging.cpp
@@ -69,8 +69,9 @@ void dsn_log_init(const std::string &logging_factory_name,
     dsn_log_start_level =
         enum_from_string(FLAGS_logging_start_level, dsn_log_level_t::LOG_LEVEL_INVALID);
 
-    dassert(dsn_log_start_level != dsn_log_level_t::LOG_LEVEL_INVALID,
-            "invalid [core] logging_start_level specified");
+    CHECK_NE_MSG(dsn_log_start_level,
+                 dsn_log_level_t::LOG_LEVEL_INVALID,
+                 "invalid [core] logging_start_level specified");
 
     // register log flush on exit
     if (FLAGS_logging_flush_on_exit) {

--- a/src/utils/long_adder.cpp
+++ b/src/utils/long_adder.cpp
@@ -78,8 +78,9 @@ cacheline_aligned_int64 *const kCellsLocked = reinterpret_cast<cacheline_aligned
     cacheline_aligned_int64 *array = new (buffer) cacheline_aligned_int64[size];
     for (uint32_t i = 0; i < size; ++i) {
         cacheline_aligned_int64 *elem = &(array[i]);
-        dassert_f(
-            (reinterpret_cast<const uintptr_t>(elem) & (sizeof(cacheline_aligned_int64) - 1)) == 0,
+        CHECK_EQ_MSG(
+            (reinterpret_cast<const uintptr_t>(elem) & (sizeof(cacheline_aligned_int64) - 1)),
+            0,
             "unaligned cacheline_aligned_int64: array={}, index={}, elem={}, mask={}",
             fmt::ptr(array),
             i,
@@ -185,8 +186,9 @@ void striped_long_adder::increment_by(int64_t x)
     cacheline_aligned_int64 *cells = _cells.load(std::memory_order_acquire);
     if (cells != nullptr && cells != kCellsLocked) {
         cacheline_aligned_int64 *cell = &(cells[get_tls_hashcode() & kCellMask]);
-        dassert_f(
-            (reinterpret_cast<const uintptr_t>(cell) & (sizeof(cacheline_aligned_int64) - 1)) == 0,
+        CHECK_EQ_MSG(
+            (reinterpret_cast<const uintptr_t>(cell) & (sizeof(cacheline_aligned_int64) - 1)),
+            0,
             "unaligned cacheline_aligned_int64 not allowed for striped64: cell={}, mask={}",
             fmt::ptr(cell),
             sizeof(cacheline_aligned_int64) - 1);

--- a/src/utils/output_utils.cpp
+++ b/src/utils/output_utils.cpp
@@ -49,7 +49,7 @@ void json_encode(Writer &writer, const table_printer &tp)
             dsn::json::json_encode(writer, tp._matrix_data[row][1]); // row data
         }
     } else {
-        dassert(false, "Unknown mode");
+        CHECK(false, "Unknown mode");
     }
     if (!tp._name.empty()) {
         writer.EndObject();
@@ -59,7 +59,7 @@ void json_encode(Writer &writer, const table_printer &tp)
 void table_printer::add_title(const std::string &title, alignment align)
 {
     check_mode(data_mode::kMultiColumns);
-    dassert(_matrix_data.empty() && _max_col_width.empty(), "`add_title` must be called only once");
+    CHECK(_matrix_data.empty() && _max_col_width.empty(), "'add_title' must be called only once");
     _max_col_width.push_back(title.length());
     _align_left.push_back(align == alignment::kLeft);
     add_row(title);
@@ -103,7 +103,7 @@ void table_printer::output(std::ostream &out, output_format format) const
         output_in_json<dsn::json::PrettyJsonWriter>(out);
         break;
     default:
-        dassert(false, "Unknown format");
+        CHECK(false, "Unknown format");
     }
 }
 
@@ -172,7 +172,7 @@ void multi_table_printer::output(std::ostream &out,
         output_in_json<dsn::json::PrettyJsonWriter>(out);
         break;
     default:
-        dassert(false, "Unknown format");
+        CHECK(false, "Unknown format");
     }
 }
 

--- a/src/utils/simple_logger.cpp
+++ b/src/utils/simple_logger.cpp
@@ -119,9 +119,9 @@ simple_logger::simple_logger(const char *log_dir) : logging_provider(log_dir)
 
     // check existing log files
     std::vector<std::string> sub_list;
-    if (!dsn::utils::filesystem::get_subfiles(_log_dir, sub_list, false)) {
-        dassert(false, "Fail to get subfiles in %s.", _log_dir.c_str());
-    }
+    CHECK(dsn::utils::filesystem::get_subfiles(_log_dir, sub_list, false),
+          "Fail to get subfiles in {}",
+          _log_dir);
     for (auto &fpath : sub_list) {
         auto &&name = dsn::utils::filesystem::get_file_name(fpath);
         if (name.length() <= 8 || name.substr(0, 4) != "log.")

--- a/src/zookeeper/lock_struct.cpp
+++ b/src/zookeeper/lock_struct.cpp
@@ -211,7 +211,7 @@ void lock_struct::owner_change(lock_struct_ptr _this, int zoo_event)
     } else if (ZOO_NOTWATCHING_EVENT == zoo_event)
         _this->get_lock_owner(false);
     else
-        dassert(false, "unexpected event");
+        CHECK(false, "unexpected event");
 }
 /*static*/
 void lock_struct::after_remove_duplicated_locknode(lock_struct_ptr _this,
@@ -575,7 +575,7 @@ void lock_struct::after_create_locknode(lock_struct_ptr _this,
     char splitter[] = {'/', 0};
     _this->_myself._node_seq_name = utils::get_last_component(*path, splitter);
     _this->_myself._sequence_id = parse_seq_path(_this->_myself._node_seq_name);
-    dassert(_this->_myself._sequence_id != -1, "invalid seq path created");
+    CHECK_NE_MSG(_this->_myself._sequence_id, -1, "invalid seq path created");
     LOG_INFO("create seq/ephe node in dir(%s) ok, my_sequence_id(%d)",
              _this->_lock_dir.c_str(),
              _this->_myself._sequence_id);

--- a/src/zookeeper/test/distributed_lock_zookeeper.cpp
+++ b/src/zookeeper/test/distributed_lock_zookeeper.cpp
@@ -94,7 +94,7 @@ public:
                              version);
                 },
                 DLOCK_CALLBACK,
-                [](error_code, const std::string &, int) { dassert(false, "session expired"); },
+                [](error_code, const std::string &, int) { CHECK(false, "session expired"); },
                 opt);
             task_pair.first->wait();
             for (int i = 0; i < 1000; ++i) {

--- a/src/zookeeper/zookeeper_session.cpp
+++ b/src/zookeeper/zookeeper_session.cpp
@@ -174,7 +174,7 @@ int zookeeper_session::attach(void *callback_owner, const state_callback &cb)
                                      this,
                                      0);
         }
-        dassert(_handle != nullptr, "zookeeper session init failed");
+        CHECK_NOTNULL(_handle, "zookeeper session init failed");
     }
 
     _watchers.push_back(watcher_object());


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1204

- `dassert` -> `CHECK`
- `dassert/dassert_f(a == b, msg)` -> `CHECK_EQ_MSG(a, b, msg)`
- `dassert/dassert_f(a > b, msg)` -> `CHECK_GT_MSG(a, b, msg)`
- `dassert/dassert_f(a >= b, msg)` -> `CHECK_GE_MSG(a, b, msg)`
- `dassert/dassert_f(a < b, msg)` -> `CHECK_LT_MSG(a, b, msg)`
- `dassert/dassert_f(a <= b, msg)` -> `CHECK_LE_MSG(a, b, msg)`
- remove some verbose messages

TODO: remove `CHECK(false, ...)`