### PR TITLE
refactor(log): use LOG_INFO_F instead of LOG_INFO (3/3)

### DIFF
--- a/src/aio/test/aio.cpp
+++ b/src/aio/test/aio.cpp
@@ -188,7 +188,7 @@ TEST(core, operation_failed)
 
     t = ::dsn::file::read(fp2, buffer, 512, 100, LPC_AIO_TEST, nullptr, io_callback, 0);
     t->wait();
-    LOG_INFO("error code: %s", err->to_string());
+    LOG_INFO_F("error code: {}", *err);
     file::close(fp);
     file::close(fp2);
     fail::teardown();

--- a/src/block_service/block_service_manager.cpp
+++ b/src/block_service/block_service_manager.cpp
@@ -52,7 +52,7 @@ block_service_manager::block_service_manager()
 
 block_service_manager::~block_service_manager()
 {
-    LOG_INFO("close block service manager.");
+    LOG_INFO_F("close block service manager.");
     zauto_write_lock l(_fs_lock);
     _fs_map.clear();
 }

--- a/src/block_service/fds/fds_service.cpp
+++ b/src/block_service/fds/fds_service.cpp
@@ -561,7 +561,7 @@ error_code fds_file_object::put_content(/*in-out*/ std::istream &is,
         return err;
     }
 
-    LOG_INFO("start to synchronize meta data after successfully wrote data to fds");
+    LOG_INFO_F("start to synchronize meta data after successfully wrote data to fds");
     err = get_file_meta();
     if (err == ERR_OK) {
         transfered_bytes = _size;

--- a/src/block_service/hdfs/hdfs_service.cpp
+++ b/src/block_service/hdfs/hdfs_service.cpp
@@ -113,7 +113,7 @@ void hdfs_service::close()
     // This method should be carefully called.
     // Calls to hdfsDisconnect() by individual threads would terminate
     // all other connections handed out via hdfsConnect() to the same URI.
-    LOG_INFO("Try to disconnect hdfs.");
+    LOG_INFO_F("Try to disconnect hdfs.");
     int result = hdfsDisconnect(_fs);
     if (result == -1) {
         LOG_ERROR_F("Fail to disconnect from the hdfs file system, error: {}.",
@@ -335,7 +335,7 @@ error_code hdfs_file_object::write_data_in_batches(const char *data,
         return ERR_FS_INTERNAL;
     }
 
-    LOG_INFO("start to synchronize meta data after successfully wrote data to hdfs");
+    LOG_INFO_F("start to synchronize meta data after successfully wrote data to hdfs");
     return get_file_meta();
 }
 

--- a/src/block_service/local/local_service.cpp
+++ b/src/block_service/local/local_service.cpp
@@ -78,7 +78,7 @@ error_code local_service::initialize(const std::vector<std::string> &args)
         _root = args[0];
 
     if (_root.empty()) {
-        LOG_INFO("initialize local block service succeed with empty root");
+        LOG_INFO_F("initialize local block service succeed with empty root");
     } else {
         if (::dsn::utils::filesystem::directory_exists(_root)) {
             LOG_WARNING("old local block service root dir has already exist, path(%s)",
@@ -88,7 +88,7 @@ error_code local_service::initialize(const std::vector<std::string> &args)
                   "local block service create directory({}) fail",
                   _root);
         }
-        LOG_INFO("local block service initialize succeed with root(%s)", _root.c_str());
+        LOG_INFO_F("local block service initialize succeed with root({})", _root);
     }
     return ERR_OK;
 }
@@ -110,10 +110,10 @@ dsn::task_ptr local_service::list_dir(const ls_request &req,
         resp.err = ERR_OK;
 
         if (::dsn::utils::filesystem::file_exists(dir_path)) {
-            LOG_INFO("list_dir: invalid parameter(%s)", dir_path.c_str());
+            LOG_INFO_F("list_dir: invalid parameter({})", dir_path);
             resp.err = ERR_INVALID_PARAMETERS;
         } else if (!::dsn::utils::filesystem::directory_exists(dir_path)) {
-            LOG_INFO("directory does not exist, dir = %s", dir_path.c_str());
+            LOG_INFO_F("directory does not exist, dir = {}", dir_path);
             resp.err = ERR_OBJECT_NOT_FOUND;
         } else {
             if (!::dsn::utils::filesystem::get_subfiles(dir_path, children, false)) {

--- a/src/common/fs_manager.cpp
+++ b/src/common/fs_manager.cpp
@@ -177,10 +177,7 @@ dsn::error_code fs_manager::initialize(const std::vector<std::string> &data_dirs
         utils::filesystem::get_normalized_path(data_dirs[i], norm_path);
         dir_node *n = new dir_node(tags[i], norm_path);
         _dir_nodes.emplace_back(n);
-        LOG_INFO("%s: mark data dir(%s) as tag(%s)",
-                 dsn_primary_address().to_string(),
-                 norm_path.c_str(),
-                 tags[i].c_str());
+        LOG_INFO_F("{}: mark data dir({}) as tag({})", dsn_primary_address(), norm_path, tags[i]);
     }
     _available_data_dirs = data_dirs;
 
@@ -221,11 +218,7 @@ void fs_manager::add_replica(const gpid &pid, const std::string &pid_dir)
                         pid.get_partition_index(),
                         n->tag.c_str());
         } else {
-            LOG_INFO("%s: add gpid(%d.%d) to dir_node(%s)",
-                     dsn_primary_address().to_string(),
-                     pid.get_app_id(),
-                     pid.get_partition_index(),
-                     n->tag.c_str());
+            LOG_INFO_F("{}: add gpid({}) to dir_node({})", dsn_primary_address(), pid, n->tag);
         }
     }
 }
@@ -258,12 +251,11 @@ void fs_manager::allocate_dir(const gpid &pid, const std::string &type, /*out*/ 
         }
     }
 
-    LOG_INFO(
-        "%s: put pid(%d.%d) to dir(%s), which has %u replicas of current app, %u replicas totally",
-        dsn_primary_address().to_string(),
-        pid.get_app_id(),
-        pid.get_partition_index(),
-        selected->tag.c_str(),
+    LOG_INFO_F(
+        "{}: put pid({}) to dir({}), which has {} replicas of current app, {} replicas totally",
+        dsn_primary_address(),
+        pid,
+        selected->tag,
         least_app_replicas_count,
         least_total_replicas_count);
 
@@ -283,11 +275,7 @@ void fs_manager::remove_replica(const gpid &pid)
                      pid,
                      n->tag);
         if (r != 0) {
-            LOG_INFO("%s: remove gpid(%d.%d) from dir(%s)",
-                     dsn_primary_address().to_string(),
-                     pid.get_app_id(),
-                     pid.get_partition_index(),
-                     n->tag.c_str());
+            LOG_INFO_F("{}: remove gpid({}) from dir({})", dsn_primary_address(), pid, n->tag);
         }
         remove_count += r;
     }

--- a/src/failure_detector/failure_detector_multimaster.cpp
+++ b/src/failure_detector/failure_detector_multimaster.cpp
@@ -74,14 +74,14 @@ void slave_failure_detector_with_multimaster::end_ping(::dsn::error_code err,
                                                        const fd::beacon_ack &ack,
                                                        void *)
 {
-    LOG_INFO("end ping result, error[%s], time[%" PRId64
-             "], ack.this_node[%s], ack.primary_node[%s], ack.is_master[%s], ack.allowed[%s]",
-             err.to_string(),
-             ack.time,
-             ack.this_node.to_string(),
-             ack.primary_node.to_string(),
-             ack.is_master ? "true" : "false",
-             ack.allowed ? "true" : "false");
+    LOG_INFO_F("end ping result, error[{}], time[{}], ack.this_node[{}], ack.primary_node[{}], "
+               "ack.is_master[{}], ack.allowed[{}]",
+               err,
+               ack.time,
+               ack.this_node,
+               ack.primary_node,
+               ack.is_master ? "true" : "false",
+               ack.allowed ? "true" : "false");
 
     zauto_lock l(failure_detector::_lock);
     if (!failure_detector::end_ping_internal(err, ack))

--- a/src/http/pprof_http_service.cpp
+++ b/src/http/pprof_http_service.cpp
@@ -73,7 +73,7 @@ static int extract_symbols_from_binary(std::map<uintptr_t, std::string> &addr_ma
     std::string cmd = "nm -C -p ";
     cmd.append(lib_info.path);
     std::stringstream ss;
-    LOG_INFO("executing `%s`", cmd.c_str());
+    LOG_INFO_F("executing `{}`", cmd);
     const int rc = utils::pipe_execute(cmd.c_str(), ss);
     if (rc < 0) {
         LOG_ERROR("fail to popen `%s`", cmd.c_str());
@@ -162,7 +162,7 @@ static int extract_symbols_from_binary(std::map<uintptr_t, std::string> &addr_ma
         addr_map[lib_info.end_addr] = std::string();
     }
     tm.stop();
-    LOG_INFO("Loaded %s in %zdms", lib_info.path.c_str(), tm.m_elapsed());
+    LOG_INFO_F("Loaded {} in {}ms", lib_info.path, tm.m_elapsed().count());
     return 0;
 }
 
@@ -259,11 +259,11 @@ static void load_symbols()
     }
     tm2.stop();
     if (num_removed) {
-        LOG_INFO("Removed %zd entries in %zdms", num_removed, tm2.m_elapsed());
+        LOG_INFO_F("Removed {} entries in {}ms", num_removed, tm2.m_elapsed().count());
     }
 
     tm.stop();
-    LOG_INFO("Loaded all symbols in %zdms", tm.m_elapsed());
+    LOG_INFO_F("Loaded all symbols in {}ms", tm.m_elapsed().count());
 }
 
 static void find_symbols(std::string *out, std::vector<uintptr_t> &addr_list)
@@ -401,7 +401,7 @@ ssize_t read_command_line(char *buf, size_t len, bool with_args)
             }
         }
         if ((size_t)nr == len) {
-            LOG_INFO("buf is not big enough");
+            LOG_INFO_F("buf is not big enough");
             return -1;
         }
         return nr;
@@ -432,7 +432,7 @@ void pprof_http_service::growth_handler(const http_request &req, http_response &
     }
 
     MallocExtension *malloc_ext = MallocExtension::instance();
-    LOG_INFO("received requests for growth profile");
+    LOG_INFO_F("received requests for growth profile");
     malloc_ext->GetHeapGrowthStacks(&resp.body);
 
     _in_pprof_action.store(false);

--- a/src/meta/app_balance_policy.cpp
+++ b/src/meta/app_balance_policy.cpp
@@ -96,11 +96,11 @@ void app_balance_policy::balance(bool checker, const meta_view *global_view, mig
 bool app_balance_policy::need_balance_secondaries(bool balance_checker)
 {
     if (!balance_checker && !_migration_result->empty()) {
-        LOG_INFO("stop to do secondary balance coz we already have actions to do");
+        LOG_INFO_F("stop to do secondary balance coz we already have actions to do");
         return false;
     }
     if (_only_primary_balancer) {
-        LOG_INFO("stop to do secondary balancer coz it is not allowed");
+        LOG_INFO_F("stop to do secondary balancer coz it is not allowed");
         return false;
     }
     return true;

--- a/src/meta/greedy_load_balancer.cpp
+++ b/src/meta/greedy_load_balancer.cpp
@@ -154,10 +154,7 @@ bool greedy_load_balancer::all_replica_infos_collected(const node_state &ns)
     return ns.for_each_partition([this, n](const dsn::gpid &pid) {
         config_context &cc = *get_config_context(*(t_global_view->apps), pid);
         if (cc.find_from_serving(n) == cc.serving.end()) {
-            LOG_INFO("meta server hasn't collected gpid(%d.%d)'s info of %s",
-                     pid.get_app_id(),
-                     pid.get_partition_index(),
-                     n.to_string());
+            LOG_INFO_F("meta server hasn't collected gpid({})'s info of {}", pid, n);
             return false;
         }
         return true;
@@ -189,7 +186,7 @@ void greedy_load_balancer::greedy_balancer(const bool balance_checker)
 
 bool greedy_load_balancer::balance(meta_view view, migration_list &list)
 {
-    LOG_INFO("balancer round");
+    LOG_INFO_F("balancer round");
     list.clear();
 
     t_alive_nodes = view.nodes->size();
@@ -203,7 +200,7 @@ bool greedy_load_balancer::balance(meta_view view, migration_list &list)
 
 bool greedy_load_balancer::check(meta_view view, migration_list &list)
 {
-    LOG_INFO("balance checker round");
+    LOG_INFO_F("balance checker round");
     list.clear();
 
     t_alive_nodes = view.nodes->size();

--- a/src/meta/load_balance_policy.cpp
+++ b/src/meta/load_balance_policy.cpp
@@ -155,13 +155,12 @@ generate_balancer_request(const app_mapper &apps,
     default:
         CHECK(false, "");
     }
-    LOG_INFO("generate balancer: %d.%d %s from %s of disk_tag(%s) to %s",
-             pc.pid.get_app_id(),
-             pc.pid.get_partition_index(),
-             ans.c_str(),
-             from.to_string(),
-             get_disk_tag(apps, from, pc.pid).c_str(),
-             to.to_string());
+    LOG_INFO_F("generate balancer: {} {} from {} of disk_tag({}) to {}",
+               pc.pid,
+               ans,
+               from,
+               get_disk_tag(apps, from, pc.pid),
+               to);
     return std::make_shared<configuration_balancer_request>(std::move(result));
 }
 
@@ -370,8 +369,8 @@ bool load_balance_policy::execute_balance(
         if (!balance_checker) {
             if (!_migration_result->empty()) {
                 if (balance_in_turn) {
-                    LOG_INFO("stop to handle more apps after we found some actions for %s",
-                             app->get_logname());
+                    LOG_INFO_F("stop to handle more apps after we found some actions for {}",
+                               app->get_logname());
                     return false;
                 }
             }

--- a/src/meta/meta_backup_service.h
+++ b/src/meta/meta_backup_service.h
@@ -92,6 +92,10 @@ struct backup_start_time
            << std::setfill('0') << std::to_string(minute);
         return ss.str();
     }
+    friend std::ostream &operator<<(std::ostream &os, const backup_start_time &t)
+    {
+        return os << t.to_string();
+    }
     // NOTICE: this function will modify hour and minute, if time is invalid, this func will set
     // hour = 24, minute = 0
     bool parse_from(const std::string &time)

--- a/src/meta/meta_data.cpp
+++ b/src/meta/meta_data.cpp
@@ -155,14 +155,13 @@ bool construct_replica(meta_view view, const gpid &pid, int max_replica_count)
     pc.partition_flags = 0;
     pc.max_replica_count = max_replica_count;
 
-    LOG_INFO("construct for (%d.%d), select %s as primary, ballot(%" PRId64
-             "), committed_decree(%" PRId64 "), prepare_decree(%" PRId64 ")",
-             pid.get_app_id(),
-             pid.get_partition_index(),
-             server.node.to_string(),
-             server.ballot,
-             server.last_committed_decree,
-             server.last_prepared_decree);
+    LOG_INFO_F("construct for ({}), select {} as primary, ballot({}), committed_decree({}), "
+               "prepare_decree({})",
+               pid,
+               server.node,
+               server.ballot,
+               server.last_committed_decree,
+               server.last_prepared_decree);
 
     drop_list.pop_back();
 
@@ -178,14 +177,13 @@ bool construct_replica(meta_view view, const gpid &pid, int max_replica_count)
             break;
         // similar to cc.drop_list, pc.last_drop is also a stack structure
         pc.last_drops.insert(pc.last_drops.begin(), iter->node);
-        LOG_INFO("construct for (%d.%d), select %s into last_drops, ballot(%" PRId64
-                 "), committed_decree(%" PRId64 "), prepare_decree(%" PRId64 ")",
-                 pid.get_app_id(),
-                 pid.get_partition_index(),
-                 iter->node.to_string(),
-                 iter->ballot,
-                 iter->last_committed_decree,
-                 iter->last_prepared_decree);
+        LOG_INFO_F("construct for ({}), select {} into last_drops, ballot({}), "
+                   "committed_decree({}), prepare_decree({})",
+                   pid,
+                   iter->node,
+                   iter->ballot,
+                   iter->last_committed_decree,
+                   iter->last_prepared_decree);
     }
 
     cc.prefered_dropped = (int)drop_list.size() - 1;
@@ -244,10 +242,9 @@ void proposal_actions::track_current_learner(const dsn::rpc_address &node, const
             // if we've collected inforamtions for the learner, then it claims it's down
             // we will treat the learning process failed
             if (current_learner.ballot != invalid_ballot) {
-                LOG_INFO("%d.%d: a learner's is down to status(%s), perhaps learn failed",
-                         info.pid.get_app_id(),
-                         info.pid.get_partition_index(),
-                         dsn::enum_to_string(info.status));
+                LOG_INFO_F("{}: a learner's is down to status({}), perhaps learn failed",
+                           info.pid,
+                           dsn::enum_to_string(info.status));
                 learning_progress_abnormal_detected = true;
             } else {
                 LOG_DEBUG_F(

--- a/src/meta/meta_server_failure_detector.cpp
+++ b/src/meta/meta_server_failure_detector.cpp
@@ -136,10 +136,10 @@ void meta_server_failure_detector::acquire_leader_lock()
             // lock granted
             LPC_META_SERVER_LEADER_LOCK_CALLBACK,
             [this, &err](error_code ec, const std::string &owner, uint64_t version) {
-                LOG_INFO("leader lock granted callback: err(%s), owner(%s), version(%llu)",
-                         ec.to_string(),
-                         owner.c_str(),
-                         version);
+                LOG_INFO_F("leader lock granted callback: err({}), owner({}), version({})",
+                           ec,
+                           owner,
+                           version);
                 err = ec;
                 if (err == dsn::ERR_OK) {
                     leader_initialize(owner);
@@ -178,11 +178,11 @@ void meta_server_failure_detector::reset_stability_stat(const rpc_address &node)
     if (iter == _stablity.end())
         return;
     else {
-        LOG_INFO("old stability stat: node(%s), start_time(%lld), unstable_count(%d), will reset "
-                 "unstable count to 0",
-                 node.to_string(),
-                 iter->second.last_start_time_ms,
-                 iter->second.unstable_restart_count);
+        LOG_INFO_F("old stability stat: node({}), start_time({}), unstable_count({}), will reset "
+                   "unstable count to 0",
+                   node,
+                   iter->second.last_start_time_ms,
+                   iter->second.unstable_restart_count);
         iter->second.unstable_restart_count = 0;
     }
 }
@@ -213,16 +213,16 @@ bool meta_server_failure_detector::update_stability_stat(const fd::beacon_msg &b
             if (dsn_now_ms() - w.last_start_time_ms >=
                     _fd_opts->stable_rs_min_running_seconds * 1000 &&
                 w.unstable_restart_count > 0) {
-                LOG_INFO("%s has stably run for a while, reset it's unstable count(%d) to 0",
-                         beacon.from_addr.to_string(),
-                         w.unstable_restart_count);
+                LOG_INFO_F("{} has stably run for a while, reset it's unstable count({}) to 0",
+                           beacon.from_addr,
+                           w.unstable_restart_count);
                 w.unstable_restart_count = 0;
             }
         } else if (beacon.start_time > w.last_start_time_ms) {
-            LOG_INFO("check %s restarted, last_time(%lld), this_time(%lld)",
-                     beacon.from_addr.to_string(),
-                     w.last_start_time_ms,
-                     beacon.start_time);
+            LOG_INFO_F("check {} restarted, last_time({}), this_time({})",
+                       beacon.from_addr,
+                       w.last_start_time_ms,
+                       beacon.start_time);
             if (beacon.start_time - w.last_start_time_ms <
                 _fd_opts->stable_rs_min_running_seconds * 1000) {
                 w.unstable_restart_count++;
@@ -230,11 +230,11 @@ bool meta_server_failure_detector::update_stability_stat(const fd::beacon_msg &b
                             beacon.from_addr.to_string(),
                             w.unstable_restart_count);
             } else if (w.unstable_restart_count > 0) {
-                LOG_INFO("%s restart in %lld ms after last restart, may recover ok, reset "
-                         "it's unstable count(%d) to 0",
-                         beacon.from_addr.to_string(),
-                         beacon.start_time - w.last_start_time_ms,
-                         w.unstable_restart_count);
+                LOG_INFO_F("{} restart in {} ms after last restart, may recover ok, reset "
+                           "it's unstable count({}) to 0",
+                           beacon.from_addr,
+                           beacon.start_time - w.last_start_time_ms,
+                           w.unstable_restart_count);
                 w.unstable_restart_count = 0;
             }
 
@@ -270,13 +270,13 @@ void meta_server_failure_detector::on_ping(const fd::beacon_msg &beacon,
         failure_detector::on_ping_internal(beacon, ack);
     }
 
-    LOG_INFO("on_ping, beacon send time[%ld], is_master(%s), from_node(%s), this_node(%s), "
-             "primary_node(%s)",
-             ack.time,
-             ack.is_master ? "true" : "false",
-             beacon.from_addr.to_string(),
-             ack.this_node.to_string(),
-             ack.primary_node.to_string());
+    LOG_INFO_F("on_ping, beacon send time[{}], is_master({}), from_node({}), this_node({}), "
+               "primary_node({})",
+               ack.time,
+               ack.is_master ? "true" : "false",
+               beacon.from_addr,
+               ack.this_node,
+               ack.primary_node);
 
     reply(ack);
 }
@@ -285,7 +285,7 @@ void meta_server_failure_detector::on_ping(const fd::beacon_msg &beacon,
 meta_server_failure_detector::meta_server_failure_detector(rpc_address leader_address,
                                                            bool is_myself_leader)
 {
-    LOG_INFO("set %s as leader", leader_address.to_string());
+    LOG_INFO_F("set {} as leader", leader_address);
     _lock_svc = nullptr;
     _is_leader.store(is_myself_leader);
 }
@@ -293,7 +293,7 @@ meta_server_failure_detector::meta_server_failure_detector(rpc_address leader_ad
 void meta_server_failure_detector::set_leader_for_test(rpc_address leader_address,
                                                        bool is_myself_leader)
 {
-    LOG_INFO("set %s as leader", leader_address.to_string());
+    LOG_INFO_F("set {} as leader", leader_address);
     _is_leader.store(is_myself_leader);
 }
 

--- a/src/meta/meta_service.h
+++ b/src/meta/meta_service.h
@@ -370,7 +370,7 @@ bool meta_service::check_status(TRpcHolder rpc, rpc_address *forward_address)
 {
     if (!_access_controller->allowed(rpc.dsn_request())) {
         rpc.response().err = ERR_ACL_DENY;
-        LOG_INFO("reject request with ERR_ACL_DENY");
+        LOG_INFO_F("reject request with ERR_ACL_DENY");
         return false;
     }
 
@@ -385,7 +385,7 @@ bool meta_service::check_status(TRpcHolder rpc, rpc_address *forward_address)
         } else {
             rpc.response().err = ERR_SERVICE_NOT_ACTIVE;
         }
-        LOG_INFO("reject request with %s", rpc.response().err.to_string());
+        LOG_INFO_F("reject request with {}", rpc.response().err);
         return false;
     }
 
@@ -396,7 +396,7 @@ template <typename TRespType>
 bool meta_service::check_status_with_msg(message_ex *req, TRespType &response_struct)
 {
     if (!_access_controller->allowed(req)) {
-        LOG_INFO("reject request with ERR_ACL_DENY");
+        LOG_INFO_F("reject request with ERR_ACL_DENY");
         response_struct.err = ERR_ACL_DENY;
         reply(req, response_struct);
         return false;
@@ -414,7 +414,7 @@ bool meta_service::check_status_with_msg(message_ex *req, TRespType &response_st
         } else {
             response_struct.err = ERR_SERVICE_NOT_ACTIVE;
         }
-        LOG_INFO("reject request with %s", response_struct.err.to_string());
+        LOG_INFO_F("reject request with {}", response_struct.err);
         reply(req, response_struct);
         return false;
     }

--- a/src/meta/meta_state_service_zookeeper.cpp
+++ b/src/meta/meta_state_service_zookeeper.cpp
@@ -168,7 +168,7 @@ error_code meta_state_service_zookeeper::initialize(const std::vector<std::strin
             return ERR_TIMEOUT;
     }
 
-    LOG_INFO("init meta_state_service_zookeeper succeed");
+    LOG_INFO_F("init meta_state_service_zookeeper succeed");
 
     // Notice: this reference is released in finalize
     add_ref();

--- a/src/meta/partition_guardian.cpp
+++ b/src/meta/partition_guardian.cpp
@@ -187,11 +187,10 @@ bool partition_guardian::from_proposals(meta_view &view,
 invalid_action:
     std::stringstream ss;
     ss << action;
-    LOG_INFO("proposal action(%s) for gpid(%d.%d) is invalid, clear all proposal actions: %s",
-             ss.str().c_str(),
-             gpid.get_app_id(),
-             gpid.get_partition_index(),
-             reason);
+    LOG_INFO_F("proposal action({}) for gpid({}) is invalid, clear all proposal actions: {}",
+               ss.str(),
+               gpid,
+               reason);
     action.type = config_type::CT_INVALID;
 
     while (!cc.lb_actions.empty()) {
@@ -293,17 +292,17 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
             const dropped_replica &dr = cc.dropped[i];
             char time_buf[30];
             ::dsn::utils::time_ms_to_string(dr.time, time_buf);
-            LOG_INFO("%s: config_context.dropped[%d]: "
-                     "node(%s), time(%" PRIu64 "){%s}, ballot(%" PRId64 "), "
-                     "commit_decree(%" PRId64 "), prepare_decree(%" PRId64 ")",
-                     gpid_name,
-                     i,
-                     dr.node.to_string(),
-                     dr.time,
-                     time_buf,
-                     dr.ballot,
-                     dr.last_committed_decree,
-                     dr.last_prepared_decree);
+            LOG_INFO_F("{}: config_context.dropped[{}]: "
+                       "node({}), time({})[{}], ballot({}), "
+                       "commit_decree({}), prepare_decree({})",
+                       gpid_name,
+                       i,
+                       dr.node,
+                       dr.time,
+                       time_buf,
+                       dr.ballot,
+                       dr.last_committed_decree,
+                       dr.last_prepared_decree);
         }
 
         for (int i = 0; i < pc.last_drops.size(); ++i) {
@@ -314,11 +313,11 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                     break;
                 }
             }
-            LOG_INFO("%s: config_context.last_drops[%d]: node(%s), dropped_index(%d)",
-                     gpid_name,
-                     i,
-                     pc.last_drops[i].to_string(),
-                     dropped_index);
+            LOG_INFO_F("{}: config_context.last_drops[{}]: node({}), dropped_index({})",
+                       gpid_name,
+                       i,
+                       pc.last_drops[i],
+                       dropped_index);
         }
 
         if (pc.last_drops.size() == 1) {
@@ -331,10 +330,10 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
             std::vector<dropped_replica> collected_info(2);
             bool ready = true;
 
-            LOG_INFO("%s: last two drops are %s and %s (the latest dropped)",
-                     gpid_name,
-                     nodes[0].to_string(),
-                     nodes[1].to_string());
+            LOG_INFO_F("{}: last two drops are {} and {} (the latest dropped)",
+                       gpid_name,
+                       nodes[0],
+                       nodes[1]);
 
             for (unsigned int i = 0; i < nodes.size(); ++i) {
                 node_state *ns = get_node_state(*view.nodes, nodes[i], false);
@@ -347,10 +346,10 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                     std::vector<dropped_replica>::iterator it = cc.find_from_dropped(nodes[i]);
                     if (it == cc.dropped.end() || it->ballot == invalid_ballot) {
                         if (ns->has_collected()) {
-                            LOG_INFO("%s: ignore %s's replica info as it doesn't exist on replica "
-                                     "server",
-                                     gpid_name,
-                                     nodes[i].to_string());
+                            LOG_INFO_F("{}: ignore {}'s replica info as it doesn't exist on "
+                                       "replica server",
+                                       gpid_name,
+                                       nodes[i]);
                             collected_info[i] = {nodes[i], 0, -1, -1, -1};
                         } else {
                             ready = false;
@@ -403,8 +402,7 @@ pc_status partition_guardian::on_missing_primary(meta_view &view, const dsn::gpi
                                               ? previous_dead.node
                                               : recent_dead.node;
                         }
-                        LOG_INFO(
-                            "%s: select %s as a new primary", gpid_name, action.node.to_string());
+                        LOG_INFO_F("{}: select {} as a new primary", gpid_name, action.node);
                     } else {
                         char buf[1000];
                         sprintf(buf,
@@ -485,25 +483,25 @@ pc_status partition_guardian::on_missing_secondary(meta_view &view, const dsn::g
         // when max_replica_count == 2, even if there is only 1 replica alive now, we will still
         // wait for replica_assign_delay_ms_for_dropouts before recover the second replica.
         is_emergency = true;
-        LOG_INFO("gpid(%s): is emergency due to too few replicas", gpid.to_string());
+        LOG_INFO_F("gpid({}): is emergency due to too few replicas", gpid);
     } else if (cc.dropped.empty()) {
         is_emergency = true;
-        LOG_INFO("gpid(%s): is emergency due to no dropped candidate", gpid.to_string());
+        LOG_INFO_F("gpid({}): is emergency due to no dropped candidate", gpid);
     } else if (has_milliseconds_expired(cc.dropped.back().time +
                                         _replica_assign_delay_ms_for_dropouts)) {
         is_emergency = true;
         char time_buf[30];
         ::dsn::utils::time_ms_to_string(cc.dropped.back().time, time_buf);
-        LOG_INFO("gpid(%s): is emergency due to lose secondary for a long time, "
-                 "last_dropped_node(%s), drop_time(%s), delay_ms(%" PRIu64 ")",
-                 gpid.to_string(),
-                 cc.dropped.back().node.to_string(),
-                 time_buf,
-                 _replica_assign_delay_ms_for_dropouts);
+        LOG_INFO_F("gpid({}): is emergency due to lose secondary for a long time, "
+                   "last_dropped_node({}), drop_time({}), delay_ms({})",
+                   gpid,
+                   cc.dropped.back().node,
+                   time_buf,
+                   _replica_assign_delay_ms_for_dropouts);
     } else if (in_black_list(cc.dropped.back().node)) {
-        LOG_INFO("gpid(%s) is emergency due to recent dropped(%s) is in black list",
-                 gpid.to_string(),
-                 cc.dropped.back().node.to_string());
+        LOG_INFO_F("gpid({}) is emergency due to recent dropped({}) is in black list",
+                   gpid,
+                   cc.dropped.back().node);
         is_emergency = true;
     }
     action.node.set_invalid();
@@ -515,51 +513,51 @@ pc_status partition_guardian::on_missing_secondary(meta_view &view, const dsn::g
                 oss << ",";
             oss << cc.dropped[i].node.to_string();
         }
-        LOG_INFO("gpid(%s): try to choose node in dropped list, dropped_list(%s), "
-                 "prefered_dropped(%d)",
-                 gpid.to_string(),
-                 oss.str().c_str(),
-                 cc.prefered_dropped);
+        LOG_INFO_F(
+            "gpid({}): try to choose node in dropped list, dropped_list({}), prefered_dropped({})",
+            gpid,
+            oss.str(),
+            cc.prefered_dropped);
         if (cc.prefered_dropped < 0 || cc.prefered_dropped >= (int)cc.dropped.size()) {
-            LOG_INFO("gpid(%s): prefered_dropped(%d) is invalid according to drop_list(size %d), "
-                     "reset it to %d (drop_list.size - 1)",
-                     gpid.to_string(),
-                     cc.prefered_dropped,
-                     (int)cc.dropped.size(),
-                     (int)cc.dropped.size() - 1);
+            LOG_INFO_F("gpid({}): prefered_dropped({}) is invalid according to drop_list(size {}), "
+                       "reset it to {} (drop_list.size - 1)",
+                       gpid,
+                       cc.prefered_dropped,
+                       cc.dropped.size(),
+                       cc.dropped.size() - 1);
             cc.prefered_dropped = (int)cc.dropped.size() - 1;
         }
 
         while (cc.prefered_dropped >= 0) {
             const dropped_replica &server = cc.dropped[cc.prefered_dropped];
             if (is_node_alive(*view.nodes, server.node)) {
-                LOG_INFO("gpid(%s): node(%s) at cc.dropped[%d] is alive now, choose it, "
-                         "and forward prefered_dropped from (%d) to (%d)",
-                         gpid.to_string(),
-                         server.node.to_string(),
-                         cc.prefered_dropped,
-                         cc.prefered_dropped,
-                         cc.prefered_dropped - 1);
+                LOG_INFO_F("gpid({}): node({}) at cc.dropped[{}] is alive now, choose it, "
+                           "and forward prefered_dropped from {} to {}",
+                           gpid,
+                           server.node,
+                           cc.prefered_dropped,
+                           cc.prefered_dropped,
+                           cc.prefered_dropped - 1);
                 action.node = server.node;
                 cc.prefered_dropped--;
                 break;
             } else {
-                LOG_INFO("gpid(%s): node(%s) at cc.dropped[%d] is not alive now, "
-                         "changed prefered_dropped from (%d) to (%d)",
-                         gpid.to_string(),
-                         server.node.to_string(),
-                         cc.prefered_dropped,
-                         cc.prefered_dropped,
-                         cc.prefered_dropped - 1);
+                LOG_INFO_F("gpid({}): node({}) at cc.dropped[{}] is not alive now, "
+                           "changed prefered_dropped from {} to {}",
+                           gpid,
+                           server.node,
+                           cc.prefered_dropped,
+                           cc.prefered_dropped,
+                           cc.prefered_dropped - 1);
                 cc.prefered_dropped--;
             }
         }
 
         if (action.node.is_invalid() || in_black_list(action.node)) {
             if (!action.node.is_invalid()) {
-                LOG_INFO("gpid(%s) refuse to use selected node(%s) as it is in black list",
-                         gpid.to_string(),
-                         action.node.to_string());
+                LOG_INFO_F("gpid({}) refuse to use selected node({}) as it is in black list",
+                           gpid,
+                           action.node);
             }
             newly_partitions *min_server_np = nullptr;
             for (auto &pairs : *view.nodes) {
@@ -575,14 +573,14 @@ pc_status partition_guardian::on_missing_secondary(meta_view &view, const dsn::g
             }
 
             if (!action.node.is_invalid()) {
-                LOG_INFO("gpid(%s): can't find valid node in dropped list to add as secondary, "
-                         "choose new node(%s) with minimal partitions serving",
-                         gpid.to_string(),
-                         action.node.to_string());
+                LOG_INFO_F("gpid({}): can't find valid node in dropped list to add as secondary, "
+                           "choose new node({}) with minimal partitions serving",
+                           gpid,
+                           action.node);
             } else {
-                LOG_INFO("gpid(%s): can't find valid node in dropped list to add as secondary, "
-                         "but also we can't find a new node to add as secondary",
-                         gpid.to_string());
+                LOG_INFO_F("gpid({}): can't find valid node in dropped list to add as secondary, "
+                           "but also we can't find a new node to add as secondary",
+                           gpid);
             }
         }
     } else {
@@ -596,15 +594,15 @@ pc_status partition_guardian::on_missing_secondary(meta_view &view, const dsn::g
         }
 
         if (!action.node.is_invalid()) {
-            LOG_INFO("gpid(%s): choose node(%s) as secondary coz it is last_dropped_node and is "
-                     "alive now",
-                     gpid.to_string(),
-                     server.node.to_string());
+            LOG_INFO_F("gpid({}): choose node({}) as secondary coz it is last_dropped_node and is "
+                       "alive now",
+                       gpid,
+                       server.node);
         } else {
-            LOG_INFO("gpid(%s): can't add secondary coz last_dropped_node(%s) is not alive now, "
-                     "ignore this as not in emergency",
-                     gpid.to_string(),
-                     server.node.to_string());
+            LOG_INFO_F("gpid({}): can't add secondary coz last_dropped_node({}) is not alive now, "
+                       "ignore this as not in emergency",
+                       gpid,
+                       server.node);
         }
     }
 
@@ -652,9 +650,9 @@ void partition_guardian::finish_cure_proposal(meta_view &view,
 {
     newly_partitions *np = get_newly_partitions(*(view.nodes), act.node);
     if (np == nullptr) {
-        LOG_INFO("can't get the newly_partitions extension structure for node(%s), "
-                 "the node may be dead and removed",
-                 act.node.to_string());
+        LOG_INFO_F("can't get the newly_partitions extension structure for node({}), "
+                   "the node may be dead and removed",
+                   act.node);
     } else {
         if (act.type == config_type::CT_ASSIGN_PRIMARY) {
             np->newly_remove_primary(gpid.get_app_id(), false);

--- a/src/meta/server_state.cpp
+++ b/src/meta/server_state.cpp
@@ -215,7 +215,7 @@ bool server_state::spin_wait_staging(int timeout_seconds)
         if (c == 0) {
             return true;
         }
-        LOG_INFO("there are (%d) apps still in staging, just wait...", c);
+        LOG_INFO_F("there are {} apps still in staging, just wait...", c);
         std::this_thread::sleep_for(std::chrono::seconds(1));
         if (timeout_seconds > 0) {
             --timeout_seconds;
@@ -272,10 +272,10 @@ void server_state::transition_staging_state(std::shared_ptr<app_state> &app)
               enum_to_string(app->status));
     }
 
-    LOG_INFO("app(%s) transfer from %s to %s",
-             app->get_logname(),
-             enum_to_string(old_status),
-             enum_to_string(app->status));
+    LOG_INFO_F("app({}) transfer from {} to {}",
+               app->get_logname(),
+               enum_to_string(old_status),
+               enum_to_string(app->status));
 #undef send_response
 }
 
@@ -328,7 +328,7 @@ error_code server_state::dump_from_remote_storage(const char *local_path, bool s
     if (sync_immediately) {
         ec = sync_apps_from_remote_storage();
         if (ec == ERR_OBJECT_NOT_FOUND) {
-            LOG_INFO("remote storage is empty, just stop the dump");
+            LOG_INFO_F("remote storage is empty, just stop the dump");
             return ERR_OK;
         } else if (ec != ERR_OK) {
             LOG_ERROR("sync from remote storage failed, err(%s)", ec.to_string());
@@ -350,7 +350,7 @@ error_code server_state::dump_from_remote_storage(const char *local_path, bool s
         {
             zauto_read_lock l(_lock);
             if (count_staging_app() != 0) {
-                LOG_INFO("there are apps in staging, skip this dump");
+                LOG_INFO_F("there are apps in staging, skip this dump");
                 return ERR_INVALID_STATE;
             }
             snapshots.reserve(_all_apps.size());
@@ -429,7 +429,7 @@ error_code server_state::initialize_default_apps()
 {
     std::vector<const char *> sections;
     dsn_config_get_all_sections(sections);
-    LOG_INFO("start to do initialize");
+    LOG_INFO_F("start to do initialize");
 
     app_info default_app;
     for (int i = 0; i < sections.size(); i++) {
@@ -502,7 +502,7 @@ error_code server_state::sync_apps_to_remote_storage()
         LOG_ERROR("create root node /apps in meta store failed, err = %s", err.to_string());
         return err;
     } else {
-        LOG_INFO("set %s to lock state in remote storage", _apps_root.c_str());
+        LOG_INFO_F("set {} to lock state in remote storage", _apps_root);
     }
 
     err = ERR_OK;
@@ -524,7 +524,7 @@ error_code server_state::sync_apps_to_remote_storage()
                                                  ec.to_string());
                                      err = ec;
                                  } else {
-                                     LOG_INFO("create app node %s ok", path.c_str());
+                                     LOG_INFO_F("create app node {} ok", path);
                                  }
                              },
                              value,
@@ -551,7 +551,7 @@ error_code server_state::sync_apps_to_remote_storage()
                                                   [&err](dsn::error_code e) { err = e; });
     t->wait();
     if (dsn::ERR_OK == err) {
-        LOG_INFO("set %s to unlock state in remote storage", _apps_root.c_str());
+        LOG_INFO_F("set {} to unlock state in remote storage", _apps_root);
         return err;
     } else {
         LOG_ERROR("set %s to unlock state in remote storage failed, reason(%s)",
@@ -756,7 +756,7 @@ error_code server_state::initialize_data_structure()
         if (_meta_svc->get_meta_options().recover_from_replica_server) {
             return ERR_OBJECT_NOT_FOUND;
         } else {
-            LOG_INFO("can't find apps from remote storage, start to initialize default apps");
+            LOG_INFO_F("can't find apps from remote storage, start to initialize default apps");
             err = initialize_default_apps();
         }
     } else if (err == ERR_OK) {
@@ -765,8 +765,8 @@ error_code server_state::initialize_data_structure()
                   "find apps from remote storage, but "
                   "[meta_server].recover_from_replica_server = true");
         } else {
-            LOG_INFO(
-                "sync apps from remote storage ok, get %d apps, init the node state accordingly",
+            LOG_INFO_F(
+                "sync apps from remote storage ok, get {} apps, init the node state accordingly",
                 _all_apps.size());
             initialize_node_state();
         }
@@ -794,9 +794,9 @@ void server_state::on_config_sync(configuration_query_by_node_rpc rpc)
 
     bool reject_this_request = false;
     response.__isset.gc_replicas = false;
-    LOG_INFO("got config sync request from %s, stored_replicas_count(%d)",
-             request.node.to_string(),
-             (int)request.stored_replicas.size());
+    LOG_INFO_F("got config sync request from {}, stored_replicas_count({})",
+               request.node,
+               request.stored_replicas.size());
 
     {
         zauto_read_lock l(_lock);
@@ -804,7 +804,7 @@ void server_state::on_config_sync(configuration_query_by_node_rpc rpc)
         // sync the partitions to the replica server
         node_state *ns = get_node_state(_nodes, request.node, false);
         if (ns == nullptr) {
-            LOG_INFO("node(%s) not found in meta server", request.node.to_string());
+            LOG_INFO_F("node({}) not found in meta server", request.node);
             response.err = ERR_OBJECT_NOT_FOUND;
         } else {
             response.err = ERR_OK;
@@ -882,23 +882,20 @@ void server_state::on_config_sync(configuration_query_by_node_rpc rpc)
                     }
                 } else if (app->status == app_status::AS_DROPPED) {
                     if (app->expire_second == 0) {
-                        LOG_INFO(
-                            "gpid(%d.%d) on node(%s) is of dropped table, but expire second is "
-                            "not specified, do not delete it for safety reason",
-                            rep.pid.get_app_id(),
-                            rep.pid.get_partition_index(),
-                            request.node.to_string());
+                        LOG_INFO_F("gpid({}) on node({}) is of dropped table, but expire second is "
+                                   "not specified, do not delete it for safety reason",
+                                   rep.pid,
+                                   request.node);
                     } else if (has_seconds_expired(app->expire_second)) {
                         // can delete replica only when expire second is explicitely specified and
                         // expired.
                         if (level <= meta_function_level::fl_steady) {
-                            LOG_INFO("gpid(%d.%d) on node(%s) is of dropped and expired table, but "
-                                     "current function level is %s, do not delete it for safety "
-                                     "reason",
-                                     rep.pid.get_app_id(),
-                                     rep.pid.get_partition_index(),
-                                     request.node.to_string(),
-                                     _meta_function_level_VALUES_TO_NAMES.find(level)->second);
+                            LOG_INFO_F("gpid({}) on node({}) is of dropped and expired table, but "
+                                       "current function level is {}, do not delete it for safety "
+                                       "reason",
+                                       rep.pid,
+                                       request.node,
+                                       _meta_function_level_VALUES_TO_NAMES.find(level)->second);
                         } else {
                             response.gc_replicas.push_back(rep);
                             LOG_WARNING(
@@ -914,13 +911,11 @@ void server_state::on_config_sync(configuration_query_by_node_rpc rpc)
                         collect_replica({&_all_apps, &_nodes}, request.node, rep);
                     if (!is_useful_replica) {
                         if (level <= meta_function_level::fl_steady) {
-                            LOG_INFO(
-                                "gpid(%d.%d) on node(%s) is useless, but current function level "
-                                "is %s, do not delete it for safety reason",
-                                rep.pid.get_app_id(),
-                                rep.pid.get_partition_index(),
-                                request.node.to_string(),
-                                _meta_function_level_VALUES_TO_NAMES.find(level)->second);
+                            LOG_INFO_F("gpid({}) on node({}) is useless, but current function "
+                                       "level is {}, do not delete it for safety reason",
+                                       rep.pid,
+                                       request.node,
+                                       _meta_function_level_VALUES_TO_NAMES.find(level)->second);
                         } else {
                             response.gc_replicas.push_back(rep);
                             LOG_WARNING("notify node(%s) to gc replica(%d.%d) coz it is useless",
@@ -1204,7 +1199,7 @@ void server_state::drop_app(dsn::message_ex *msg)
     bool do_dropping = false;
     std::shared_ptr<app_state> app;
     dsn::unmarshall(msg, request);
-    LOG_INFO("drop app request, name(%s)", request.app_name.c_str());
+    LOG_INFO_F("drop app request, name({})", request.app_name);
     {
         zauto_write_lock l(_lock);
         app = get_app(request.app_name);
@@ -1355,7 +1350,7 @@ void server_state::recall_app(dsn::message_ex *msg)
     std::shared_ptr<app_state> target_app;
 
     dsn::unmarshall(msg, request);
-    LOG_INFO("recall app request, app_id(%d)", request.app_id);
+    LOG_INFO_F("recall app request, app_id({})", request.app_id);
 
     bool do_recalling = false;
     {
@@ -1417,13 +1412,12 @@ void server_state::list_apps(const configuration_list_apps_request &request,
 
 void server_state::send_proposal(rpc_address target, const configuration_update_request &proposal)
 {
-    LOG_INFO("send proposal %s for gpid(%d.%d), ballot = %" PRId64 ", target = %s, node = %s",
-             ::dsn::enum_to_string(proposal.type),
-             proposal.config.pid.get_app_id(),
-             proposal.config.pid.get_partition_index(),
-             proposal.config.ballot,
-             target.to_string(),
-             proposal.node.to_string());
+    LOG_INFO_F("send proposal {} for gpid({}), ballot = {}, target = {}, node = {}",
+               ::dsn::enum_to_string(proposal.type),
+               proposal.config.pid,
+               proposal.config.ballot,
+               target,
+               proposal.node);
     dsn::message_ex *msg =
         dsn::message_ex::create_request(RPC_CONFIG_PROPOSAL, 0, proposal.config.pid.thread_hash());
     ::marshall(msg, proposal);
@@ -1592,15 +1586,15 @@ void server_state::update_configuration_locally(
     old_cfg = config_request->config;
     auto find_name = _config_type_VALUES_TO_NAMES.find(config_request->type);
     if (find_name != _config_type_VALUES_TO_NAMES.end()) {
-        LOG_INFO("meta update config ok: type(%s), old_config=%s, %s",
-                 find_name->second,
-                 old_config_str.c_str(),
-                 boost::lexical_cast<std::string>(*config_request).c_str());
+        LOG_INFO_F("meta update config ok: type({}), old_config={}, {}",
+                   find_name->second,
+                   old_config_str,
+                   boost::lexical_cast<std::string>(*config_request));
     } else {
-        LOG_INFO("meta update config ok: type(%d), old_config=%s, %s",
-                 config_request->type,
-                 old_config_str.c_str(),
-                 boost::lexical_cast<std::string>(*config_request).c_str());
+        LOG_INFO_F("meta update config ok: type({}), old_config={}, {}",
+                   config_request->type,
+                   old_config_str,
+                   boost::lexical_cast<std::string>(*config_request));
     }
 
 #ifndef NDEBUG
@@ -1624,8 +1618,8 @@ task_ptr server_state::update_configuration_on_remote(
 {
     meta_function_level::type l = _meta_svc->get_function_level();
     if (l <= meta_function_level::fl_blind) {
-        LOG_INFO("ignore update configuration on remote due to level is %s",
-                 _meta_function_level_VALUES_TO_NAMES.find(l)->second);
+        LOG_INFO_F("ignore update configuration on remote due to level is {}",
+                   _meta_function_level_VALUES_TO_NAMES.find(l)->second);
         // NOTICE: pending_sync_task need to be reassigned
         return tasking::enqueue(
             LPC_META_STATE_HIGH,
@@ -1849,10 +1843,10 @@ void server_state::downgrade_secondary_to_inactive(std::shared_ptr<app_state> &a
         request.node = node;
         send_proposal(pc.primary, request);
     } else {
-        LOG_INFO("gpid(%d.%d) is syncing with remote storage, ignore the remove seconary(%s)",
-                 app->app_id,
-                 pidx,
-                 node.to_string());
+        LOG_INFO_F("gpid({}.{}) is syncing with remote storage, ignore the remove seconary({})",
+                   app->app_id,
+                   pidx,
+                   node);
     }
 }
 
@@ -1918,13 +1912,13 @@ void server_state::on_update_configuration(
     CHECK(app->is_stateful, "don't support stateless apps currently, id({})", gpid.get_app_id());
     auto find_name = _config_type_VALUES_TO_NAMES.find(cfg_request->type);
     if (find_name != _config_type_VALUES_TO_NAMES.end()) {
-        LOG_INFO("recv update config request: type(%s), %s",
-                 find_name->second,
-                 boost::lexical_cast<std::string>(*cfg_request).c_str());
+        LOG_INFO_F("recv update config request: type({}), {}",
+                   find_name->second,
+                   boost::lexical_cast<std::string>(*cfg_request));
     } else {
-        LOG_INFO("recv update config request: type(%d), %s",
-                 cfg_request->type,
-                 boost::lexical_cast<std::string>(*cfg_request).c_str());
+        LOG_INFO_F("recv update config request: type({}), {}",
+                   cfg_request->type,
+                   boost::lexical_cast<std::string>(*cfg_request));
     }
 
     if (is_partition_config_equal(pc, cfg_request->config)) {

--- a/src/meta/server_state_restore.cpp
+++ b/src/meta/server_state_restore.cpp
@@ -197,11 +197,10 @@ void server_state::on_recv_restore_report(configuration_report_restore_status_rp
         if (request.__isset.reason) {
             r_state.reason = request.reason;
         }
-        LOG_INFO("%d.%d restore report: restore_status(%s), progress(%d)",
-                 request.pid.get_app_id(),
-                 request.pid.get_partition_index(),
-                 request.restore_status.to_string(),
-                 request.progress);
+        LOG_INFO_F("{} restore report: restore_status({}), progress({})",
+                   request.pid,
+                   request.restore_status,
+                   request.progress);
     }
 }
 

--- a/src/meta/test/backup_test.cpp
+++ b/src/meta/test/backup_test.cpp
@@ -76,7 +76,7 @@ protected:
     MOCK_HELPER_FUNCS(method_name)                                                                 \
     void method_name()                                                                             \
     {                                                                                              \
-        LOG_INFO("%s is called", #method_name);                                                    \
+        LOG_INFO_F("{} is called", #method_name);                                                  \
         int &c = counter_##method_name();                                                          \
         ++c;                                                                                       \
         int max_call = maxcall_##method_name();                                                    \
@@ -92,7 +92,7 @@ protected:
     MOCK_HELPER_FUNCS(method_name)                                                                 \
     void method_name(type1 arg1)                                                                   \
     {                                                                                              \
-        LOG_INFO("%s is called", #method_name);                                                    \
+        LOG_INFO_F("{} is called", #method_name);                                                  \
         int &c = counter_##method_name();                                                          \
         ++c;                                                                                       \
         int max_call = maxcall_##method_name();                                                    \
@@ -108,7 +108,7 @@ protected:
     MOCK_HELPER_FUNCS(method_name)                                                                 \
     void method_name(type1 arg1, type2 arg2)                                                       \
     {                                                                                              \
-        LOG_INFO("%s is called", #method_name);                                                    \
+        LOG_INFO_F("{} is called", #method_name);                                                  \
         int &c = counter_##method_name();                                                          \
         ++c;                                                                                       \
         int max_call = maxcall_##method_name();                                                    \
@@ -124,7 +124,7 @@ protected:
     MOCK_HELPER_FUNCS(method_name)                                                                 \
     void method_name(type1 arg1, type2 arg2, type3, arg3)                                          \
     {                                                                                              \
-        LOG_INFO("%s is called", #method_name);                                                    \
+        LOG_INFO_F("{} is called", #method_name);                                                  \
         int &c = counter_##method_name();                                                          \
         ++c;                                                                                       \
         int max_call = maxcall_##method_name();                                                    \

--- a/src/meta/test/meta_state/meta_state_service.cpp
+++ b/src/meta/test/meta_state/meta_state_service.cpp
@@ -258,7 +258,7 @@ void provider_recursively_create_delete_test(const service_creator_func &creator
         ->delete_node("/r",
                       true,
                       META_STATE_SERVICE_SIMPLE_TEST_CALLBACK,
-                      [](error_code ec) { LOG_INFO("result: %s", ec.to_string()); })
+                      [](error_code ec) { LOG_INFO_F("result: {}", ec); })
         ->wait();
     service->create_node(
         "/r",

--- a/src/meta/test/update_configuration_test.cpp
+++ b/src/meta/test/update_configuration_test.cpp
@@ -120,7 +120,7 @@ class null_meta_service : public dsn::replication::meta_service
 public:
     void send_message(const dsn::rpc_address &target, dsn::message_ex *request)
     {
-        LOG_INFO("send request to %s", target.to_string());
+        LOG_INFO_F("send request to {}", target);
         request->add_ref();
         request->release_ref();
     }

--- a/src/perf_counter/test/perf_counter_test.cpp
+++ b/src/perf_counter/test/perf_counter_test.cpp
@@ -97,19 +97,19 @@ TEST(perf_counter, perf_counter_atomic)
         "", "", "", dsn_perf_counter_type_t::COUNTER_TYPE_NUMBER, "");
     perf_counter_inc_dec(counter);
     perf_counter_add(counter, vec);
-    LOG_INFO("%lf", counter->get_value());
+    LOG_INFO_F("{}", counter->get_value());
 
     counter = new perf_counter_volatile_number_atomic(
         "", "", "", dsn_perf_counter_type_t::COUNTER_TYPE_VOLATILE_NUMBER, "");
     perf_counter_inc_dec(counter);
     perf_counter_add(counter, vec);
-    LOG_INFO("%lf", counter->get_value());
+    LOG_INFO_F("{}", counter->get_value());
 
     counter =
         new perf_counter_rate_atomic("", "", "", dsn_perf_counter_type_t::COUNTER_TYPE_RATE, "");
     perf_counter_inc_dec(counter);
     perf_counter_add(counter, vec);
-    LOG_INFO("%lf", counter->get_value());
+    LOG_INFO_F("{}", counter->get_value());
 
     counter = new perf_counter_number_percentile_atomic(
         "", "", "", dsn_perf_counter_type_t::COUNTER_TYPE_NUMBER_PERCENTILES, "");
@@ -119,7 +119,7 @@ TEST(perf_counter, perf_counter_atomic)
             counter->set(rand() % 10000);
         // std::this_thread::sleep_for(std::chrono::seconds(sleep_interval));
         for (int i = 0; i != COUNTER_PERCENTILE_COUNT; ++i)
-            LOG_INFO("%lf", counter->get_percentile((dsn_perf_counter_percentile_type_t)i));
+            LOG_INFO_F("{}", counter->get_percentile((dsn_perf_counter_percentile_type_t)i));
     }
 }
 

--- a/src/redis_protocol/proxy_lib/proxy_layer.cpp
+++ b/src/redis_protocol/proxy_lib/proxy_layer.cpp
@@ -96,7 +96,7 @@ void proxy_stub::remove_session(dsn::rpc_address remote_address)
             LOG_WARNING("%s has been removed from proxy stub", remote_address.to_string());
             return;
         }
-        LOG_INFO("remove %s from proxy stub", remote_address.to_string());
+        LOG_INFO_F("remove {} from proxy stub", remote_address);
         session = std::move(iter->second);
         _sessions.erase(iter);
     }
@@ -116,7 +116,7 @@ proxy_session::proxy_session(proxy_stub *op, dsn::message_ex *first_msg)
 proxy_session::~proxy_session()
 {
     _backup_one_request->release_ref();
-    LOG_INFO("proxy session %s destroyed", _remote_address.to_string());
+    LOG_INFO_F("proxy session {} destroyed", _remote_address);
 }
 
 void proxy_session::on_recv_request(dsn::message_ex *msg)

--- a/src/redis_protocol/proxy_ut/redis_proxy_test.cpp
+++ b/src/redis_protocol/proxy_ut/redis_proxy_test.cpp
@@ -605,7 +605,7 @@ TEST(proxy, connection)
             client_socket.shutdown(boost::asio::socket_base::shutdown_both);
             client_socket.close();
         } catch (...) {
-            LOG_INFO("exception in shutdown");
+            LOG_INFO_F("exception in shutdown");
         }
     }
 }

--- a/src/replica/duplication/duplication_sync_timer.cpp
+++ b/src/replica/duplication/duplication_sync_timer.cpp
@@ -139,7 +139,7 @@ std::vector<replica_ptr> duplication_sync_timer::get_all_replicas()
 
 void duplication_sync_timer::close()
 {
-    LOG_INFO("stop duplication sync");
+    LOG_INFO_F("stop duplication sync");
 
     {
         zauto_lock l(_lock);

--- a/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
+++ b/src/replica/storage/simple_kv/simple_kv.server.impl.cpp
@@ -45,7 +45,7 @@ namespace application {
 simple_kv_service_impl::simple_kv_service_impl(replica *r) : simple_kv_service(r), _lock(true)
 {
     reset_state();
-    LOG_INFO("simple_kv_service_impl inited");
+    LOG_INFO_F("simple_kv_service_impl inited");
 }
 
 void simple_kv_service_impl::reset_state()

--- a/src/replica/storage/simple_kv/test/case.cpp
+++ b/src/replica/storage/simple_kv/test/case.cpp
@@ -1029,7 +1029,7 @@ bool test_case::init(const std::string &case_input)
 
     forward();
 
-    LOG_INFO("=== init %s succeed", _name.c_str());
+    LOG_INFO_F("=== init {} succeed", _name);
 
     s_inited = true;
     return true;
@@ -1046,11 +1046,11 @@ void test_case::forward()
                 output(cl->to_string());
                 print(cl, "");
             }
-            LOG_INFO("=== on_case_forward:[%d]%s", cl->line_no(), cl->to_string().c_str());
+            LOG_INFO_F("=== on_case_forward:[{}]{}", cl->line_no(), cl->to_string());
         }
         _next++;
         if (_next >= _case_lines.size()) {
-            LOG_INFO("=== on_case_done");
+            LOG_INFO_F("=== on_case_done");
             g_done = true;
             break;
         }
@@ -1060,7 +1060,7 @@ void test_case::forward()
             set_case_line *scl = static_cast<set_case_line *>(cl);
             scl->apply_set();
         } else if (cl->name() == exit_case_line::NAME()) {
-            LOG_INFO("=== on_case_exit");
+            LOG_INFO_F("=== on_case_exit");
             g_done = true;
             break;
         } else {
@@ -1128,7 +1128,7 @@ bool test_case::check_skip(bool consume_one)
     skip_case_line *cl = static_cast<skip_case_line *>(c);
     if (consume_one) {
         cl->skip_one();
-        LOG_INFO("=== on_skip_one:skipped=%d/%d", cl->skipped(), cl->count());
+        LOG_INFO_F("=== on_skip_one:skipped={}/{}", cl->skipped(), cl->count());
     }
     if (cl->is_skip_done()) {
         forward();
@@ -1205,7 +1205,7 @@ void test_case::on_end_write(int id, ::dsn::error_code err, int32_t resp)
                err.to_string(),
                resp);
 
-    LOG_INFO("=== on_end_write:id=%d,err=%s,resp=%d", id, err.to_string(), resp);
+    LOG_INFO_F("=== on_end_write:id={}, err={}, resp={}", id, err, resp);
 
     if (check_skip(true)) {
         output(buf);
@@ -1247,7 +1247,7 @@ void test_case::on_end_read(int id, ::dsn::error_code err, const std::string &re
                err.to_string(),
                resp.c_str());
 
-    LOG_INFO("=== on_end_read:id=%d,err=%s,resp=%s", id, err.to_string(), resp.c_str());
+    LOG_INFO_F("=== on_end_read:id={}, err={}, resp={}", id, err, resp);
 
     if (check_skip(true)) {
         output(buf);
@@ -1280,7 +1280,7 @@ bool test_case::on_event(const event *ev)
     if (g_done)
         return true;
 
-    LOG_INFO("=== %s", ev->to_string().c_str());
+    LOG_INFO_F("=== {}", *ev);
 
     if (check_skip(false))
         return true;
@@ -1328,7 +1328,7 @@ void test_case::on_config_change(const parti_config &last, const parti_config &c
     _null_loop_count = 0; // reset null loop count
 
     std::string buf = std::string(config_case_line::NAME()) + ":" + cur.to_string();
-    LOG_INFO("=== on_config_change:%s", cur.to_string().c_str());
+    LOG_INFO_F("=== on_config_change: {}", cur);
 
     if (check_skip(true)) {
         output(buf);
@@ -1364,7 +1364,7 @@ void test_case::on_state_change(const state_snapshot &last, const state_snapshot
     _null_loop_count = 0; // reset null loop count
 
     std::string buf = std::string(state_case_line::NAME()) + ":" + cur.to_string();
-    LOG_INFO("=== on_state_change:%s\n%s", cur.to_string().c_str(), cur.diff_string(last).c_str());
+    LOG_INFO_F("=== on_state_change: {}\n{}", cur, cur.diff_string(last));
 
     if (check_skip(true)) {
         output(buf);

--- a/src/replica/storage/simple_kv/test/case.h
+++ b/src/replica/storage/simple_kv/test/case.h
@@ -199,6 +199,11 @@ public:
     virtual bool check_satisfied(const event *ev) const = 0;
 
     std::string to_string() const;
+    friend std::ostream &operator<<(std::ostream &os, const event &evt)
+    {
+        return os << evt.to_string();
+    }
+
     static event *parse(int line_no, const std::string &params);
 };
 

--- a/src/replica/storage/simple_kv/test/checker.cpp
+++ b/src/replica/storage/simple_kv/test/checker.cpp
@@ -197,12 +197,12 @@ bool test_checker::init(const std::string &name, const std::vector<service_app *
         rpc_address paddr = node.second->rpc()->primary_address();
         int port = paddr.port();
         _node_to_address[name] = paddr;
-        LOG_INFO("=== node_to_address[%s]=%s", name.c_str(), paddr.to_string());
+        LOG_INFO_F("=== node_to_address[{}]={}", name, paddr);
         _address_to_node[port] = name;
-        LOG_INFO("=== address_to_node[%u]=%s", port, name.c_str());
+        LOG_INFO_F("=== address_to_node[{}]={}", port, name);
         if (id != port) {
             _address_to_node[id] = name;
-            LOG_INFO("=== address_to_node[%u]=%s", id, name.c_str());
+            LOG_INFO_F("=== address_to_node[{}]={}", id, name);
         }
     }
 

--- a/src/replica/storage/simple_kv/test/client.cpp
+++ b/src/replica/storage/simple_kv/test/client.cpp
@@ -120,11 +120,7 @@ void simple_kv_client_app::begin_write(int id,
                                        const std::string &value,
                                        int timeout_ms)
 {
-    LOG_INFO("=== on_begin_write:id=%d,key=%s,value=%s,timeout=%d",
-             id,
-             key.c_str(),
-             value.c_str(),
-             timeout_ms);
+    LOG_INFO_F("=== on_begin_write:id={},key={},value={},timeout={}", id, key, value, timeout_ms);
     std::shared_ptr<write_context> ctx(new write_context());
     ctx->id = id;
     ctx->req.key = key;
@@ -168,7 +164,7 @@ struct read_context
 
 void simple_kv_client_app::begin_read(int id, const std::string &key, int timeout_ms)
 {
-    LOG_INFO("=== on_begin_read:id=%d,key=%s,timeout=%d", id, key.c_str(), timeout_ms);
+    LOG_INFO_F("=== on_begin_read:id={},key={},timeout={}", id, key, timeout_ms);
     std::shared_ptr<read_context> ctx(new read_context());
     ctx->id = id;
     ctx->key = key;

--- a/src/replica/storage/simple_kv/test/common.h
+++ b/src/replica/storage/simple_kv/test/common.h
@@ -172,6 +172,11 @@ struct state_snapshot
     std::string to_string() const;
     bool from_string(const std::string &str);
     std::string diff_string(const state_snapshot &other) const;
+
+    friend std::ostream &operator<<(std::ostream &os, const state_snapshot &ss)
+    {
+        return os << ss.to_string();
+    }
 };
 
 struct parti_config
@@ -201,6 +206,11 @@ struct parti_config
     std::string to_string() const;
     bool from_string(const std::string &str);
     void convert_from(const partition_configuration &c);
+
+    friend std::ostream &operator<<(std::ostream &os, const parti_config &pc)
+    {
+        return os << pc.to_string();
+    }
 };
 }
 }

--- a/src/replica/storage/simple_kv/test/injector.cpp
+++ b/src/replica/storage/simple_kv/test/injector.cpp
@@ -200,8 +200,6 @@ void test_injector::install(service_spec &svc_spec)
         spec->on_rpc_reply.put_native(inject_on_rpc_reply);
         spec->on_rpc_response_enqueue.put_native(inject_on_rpc_response_enqueue);
     }
-
-    // LOG_INFO("=== test_injector installed");
 }
 
 test_injector::test_injector(const char *name) : toollet(name) {}

--- a/src/replica/storage/simple_kv/test/simple_kv.main.cpp
+++ b/src/replica/storage/simple_kv/test/simple_kv.main.cpp
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
-    LOG_INFO("=== exiting ...");
+    LOG_INFO_F("=== exiting ...");
 
     dsn::replication::test::test_checker::instance().exit();
 

--- a/src/reporter/pegasus_counter_reporter.cpp
+++ b/src/reporter/pegasus_counter_reporter.cpp
@@ -119,9 +119,8 @@ void pegasus_counter_reporter::falcon_initialize()
     _falcon_metric.tags = fmt::format(
         "service=pegasus,cluster={},job={},port={}", _cluster_name, _app_name, _local_port);
 
-    LOG_INFO("falcon initialize: endpoint(%s), tag(%s)",
-             _falcon_metric.endpoint.c_str(),
-             _falcon_metric.tags.c_str());
+    LOG_INFO_F(
+        "falcon initialize: endpoint({}), tag({})", _falcon_metric.endpoint, _falcon_metric.tags);
 }
 
 void pegasus_counter_reporter::start()
@@ -180,7 +179,7 @@ void pegasus_counter_reporter::stop()
 void pegasus_counter_reporter::update_counters_to_falcon(const std::string &result,
                                                          int64_t timestamp)
 {
-    LOG_INFO("update counters to falcon with timestamp = %" PRId64, timestamp);
+    LOG_INFO_F("update counters to falcon with timestamp = {}", timestamp);
     http_post_request(FLAGS_falcon_host,
                       FLAGS_falcon_port,
                       FLAGS_falcon_path,
@@ -204,7 +203,7 @@ void pegasus_counter_reporter::update()
                 oss << "[" << cs.name << ", " << dsn_counter_type_to_string(cs.type) << ", "
                     << cs.value << "]" << std::endl;
             });
-        LOG_INFO("%s", oss.str().c_str());
+        LOG_INFO_F("{}", oss.str());
     }
 
     if (perf_counter_sink_t::FALCON == _perf_counter_sink) {
@@ -293,7 +292,7 @@ void pegasus_counter_reporter::update()
         });
     }
 
-    LOG_INFO("update now_ms(%lld), last_report_time_ms(%lld)", now, _last_report_time_ms);
+    LOG_INFO_F("update now_ms({}), last_report_time_ms({})", now, _last_report_time_ms);
     _last_report_time_ms = now;
 }
 

--- a/src/runtime/fault_injector.cpp
+++ b/src/runtime/fault_injector.cpp
@@ -146,8 +146,7 @@ static void fault_on_task_begin(task *this_)
     fj_opt &opt = s_fj_opts[this_->spec().code];
     if (opt.execution_extra_delay_us_max > 0) {
         auto d = rand::next_u32(0, opt.execution_extra_delay_us_max);
-        LOG_INFO(
-            "fault inject %s at %s with delay %u us", this_->spec().name.c_str(), __FUNCTION__, d);
+        LOG_INFO_F("fault inject {} at {} with delay {} us", this_->spec().name, __FUNCTION__, d);
         std::this_thread::sleep_for(std::chrono::microseconds(d));
     }
 }
@@ -168,14 +167,14 @@ static bool fault_on_aio_call(task *caller, aio_task *callee)
     switch (callee->get_aio_context()->type) {
     case AIO_Read:
         if (rand::next_double01() < s_fj_opts[callee->spec().code].disk_read_fail_ratio) {
-            LOG_INFO("fault inject %s at %s", callee->spec().name.c_str(), __FUNCTION__);
+            LOG_INFO_F("fault inject {} at {}", callee->spec().name, __FUNCTION__);
             callee->set_error_code(ERR_FILE_OPERATION_FAILED);
             return false;
         }
         break;
     case AIO_Write:
         if (rand::next_double01() < s_fj_opts[callee->spec().code].disk_write_fail_ratio) {
-            LOG_INFO("fault inject %s at %s", callee->spec().name.c_str(), __FUNCTION__);
+            LOG_INFO_F("fault inject {} at {}", callee->spec().name, __FUNCTION__);
             callee->set_error_code(ERR_FILE_OPERATION_FAILED);
             return false;
         }
@@ -192,10 +191,10 @@ static void fault_on_aio_enqueue(aio_task *this_)
     fj_opt &opt = s_fj_opts[this_->spec().code];
     if (this_->delay_milliseconds() == 0 && task_ext_for_fj::get(this_) == 0) {
         this_->set_delay(rand::next_u32(opt.disk_io_delay_ms_min, opt.disk_io_delay_ms_max));
-        LOG_INFO("fault inject %s at %s with delay %u ms",
-                 this_->spec().name.c_str(),
-                 __FUNCTION__,
-                 this_->delay_milliseconds());
+        LOG_INFO_F("fault inject {} at {} with delay {} ms",
+                   this_->spec().name,
+                   __FUNCTION__,
+                   this_->delay_milliseconds());
         task_ext_for_fj::get(this_) = 1; // ensure only fd once
     }
 }
@@ -231,17 +230,17 @@ static bool fault_on_rpc_call(task *caller, message_ex *req, rpc_response_task *
 {
     fj_opt &opt = s_fj_opts[req->local_rpc_code];
     if (rand::next_double01() < opt.rpc_request_drop_ratio) {
-        LOG_INFO("fault inject %s at %s: %s => %s",
-                 req->header->rpc_name,
-                 __FUNCTION__,
-                 req->header->from_address.to_string(),
-                 req->to_address.to_string());
+        LOG_INFO_F("fault inject {} at {}: {} => {}",
+                   req->header->rpc_name,
+                   __FUNCTION__,
+                   req->header->from_address,
+                   req->to_address);
         return false;
     } else {
         if (rand::next_double01() < opt.rpc_request_data_corrupted_ratio) {
-            LOG_INFO("corrupt the rpc call message from: %s, type: %s",
-                     req->header->from_address.to_string(),
-                     opt.rpc_message_data_corrupted_type.c_str());
+            LOG_INFO_F("corrupt the rpc call message from: {}, type: {}",
+                       req->header->from_address,
+                       opt.rpc_message_data_corrupted_type);
             corrupt_data(req, opt.rpc_message_data_corrupted_type);
         }
         return true;
@@ -255,10 +254,10 @@ static void fault_on_rpc_request_enqueue(rpc_request_task *callee)
         if (rand::next_double01() < opt.rpc_request_delay_ratio) {
             callee->set_delay(
                 rand::next_u32(opt.rpc_message_delay_ms_min, opt.rpc_message_delay_ms_max));
-            LOG_INFO("fault inject %s at %s with delay %u ms",
-                     callee->spec().name.c_str(),
-                     __FUNCTION__,
-                     callee->delay_milliseconds());
+            LOG_INFO_F("fault inject {} at {} with delay {} ms",
+                       callee->spec().name,
+                       __FUNCTION__,
+                       callee->delay_milliseconds());
             task_ext_for_fj::get(callee) = 1; // ensure only fd once
         }
     }
@@ -269,17 +268,17 @@ static bool fault_on_rpc_reply(task *caller, message_ex *msg)
 {
     fj_opt &opt = s_fj_opts[msg->local_rpc_code];
     if (rand::next_double01() < opt.rpc_response_drop_ratio) {
-        LOG_INFO("fault inject %s at %s: %s => %s",
-                 msg->header->rpc_name,
-                 __FUNCTION__,
-                 msg->header->from_address.to_string(),
-                 msg->to_address.to_string());
+        LOG_INFO_F("fault inject {} at {}: {} => {}",
+                   msg->header->rpc_name,
+                   __FUNCTION__,
+                   msg->header->from_address,
+                   msg->to_address);
         return false;
     } else {
         if (rand::next_double01() < opt.rpc_response_data_corrupted_ratio) {
-            LOG_INFO("fault injector corrupt the rpc reply message from: %s, type: %s",
-                     msg->header->from_address.to_string(),
-                     opt.rpc_message_data_corrupted_type.c_str());
+            LOG_INFO_F("fault injector corrupt the rpc reply message from: {}, type: {}",
+                       msg->header->from_address,
+                       opt.rpc_message_data_corrupted_type);
             corrupt_data(msg, opt.rpc_message_data_corrupted_type);
         }
         return true;
@@ -293,10 +292,10 @@ static void fault_on_rpc_response_enqueue(rpc_response_task *resp)
         if (rand::next_double01() < opt.rpc_response_delay_ratio) {
             resp->set_delay(
                 rand::next_u32(opt.rpc_message_delay_ms_min, opt.rpc_message_delay_ms_max));
-            LOG_INFO("fault inject %s at %s with delay %u ms",
-                     resp->spec().name.c_str(),
-                     __FUNCTION__,
-                     resp->delay_milliseconds());
+            LOG_INFO_F("fault inject {} at {} with delay {} ms",
+                       resp->spec().name,
+                       __FUNCTION__,
+                       resp->delay_milliseconds());
             task_ext_for_fj::get(resp) = 1; // ensure only fd once
         }
     }

--- a/src/runtime/rpc/asio_rpc_session.cpp
+++ b/src/runtime/rpc/asio_rpc_session.cpp
@@ -89,9 +89,7 @@ void asio_rpc_session::do_read(int read_next)
         [this](boost::system::error_code ec, std::size_t length) {
             if (!!ec) {
                 if (ec == boost::asio::error::make_error_code(boost::asio::error::eof)) {
-                    LOG_INFO("asio read from %s failed: %s",
-                             _remote_addr.to_string(),
-                             ec.message().c_str());
+                    LOG_INFO_F("asio read from {} failed: {}", _remote_addr, ec.message());
                 } else {
                     LOG_ERROR("asio read from %s failed: %s",
                               _remote_addr.to_string(),

--- a/src/runtime/rpc/network.cpp
+++ b/src/runtime/rpc/network.cpp
@@ -649,9 +649,9 @@ void connection_oriented_network::send_message(message_ex *request)
 
     // init connection if necessary
     if (new_client) {
-        LOG_INFO("client session created, remote_server = %s, current_count = %d",
-                 client->remote_address().to_string(),
-                 ip_count);
+        LOG_INFO_F("client session created, remote_server = {}, current_count = {}",
+                   client->remote_address(),
+                   ip_count);
         _client_session_count->set(ip_count);
         client->connect();
     }
@@ -691,14 +691,14 @@ void connection_oriented_network::on_server_session_accepted(rpc_session_ptr &s)
         }
     }
 
-    LOG_INFO("server session accepted, remote_client = %s, current_count = %d",
-             s->remote_address().to_string(),
-             ip_count);
+    LOG_INFO_F("server session accepted, remote_client = {}, current_count = {}",
+               s->remote_address(),
+               ip_count);
 
-    LOG_INFO("ip session %s, remote_client = %s, current_count = %d",
-             ip_conn_count == 1 ? "inserted" : "increased",
-             s->remote_address().to_string(),
-             ip_conn_count);
+    LOG_INFO_F("ip session {}, remote_client = {}, current_count = {}",
+               ip_conn_count == 1 ? "inserted" : "increased",
+               s->remote_address(),
+               ip_conn_count);
 
     _client_session_count->set(ip_count);
 }
@@ -733,20 +733,19 @@ void connection_oriented_network::on_server_session_disconnected(rpc_session_ptr
     }
 
     if (session_removed) {
-        LOG_INFO("session %s disconnected, the total client sessions count remains %d",
-                 s->remote_address().to_string(),
-                 ip_count);
+        LOG_INFO_F("session {} disconnected, the total client sessions count remains {}",
+                   s->remote_address(),
+                   ip_count);
         _client_session_count->set(ip_count);
     }
 
     if (ip_conn_count == 0) {
         // TODO(wutao1): print ip only
-        LOG_INFO("client ip %s has no more session to this server",
-                 s->remote_address().to_string());
+        LOG_INFO_F("client ip {} has no more session to this server", s->remote_address());
     } else {
-        LOG_INFO("client ip %s has still %d of sessions to this server",
-                 s->remote_address().to_string(),
-                 ip_conn_count);
+        LOG_INFO_F("client ip {} has still {} of sessions to this server",
+                   s->remote_address(),
+                   ip_conn_count);
     }
 }
 
@@ -796,9 +795,9 @@ void connection_oriented_network::on_client_session_connected(rpc_session_ptr &s
     }
 
     if (r) {
-        LOG_INFO("client session connected, remote_server = %s, current_count = %d",
-                 s->remote_address().to_string(),
-                 ip_count);
+        LOG_INFO_F("client session connected, remote_server = {}, current_count = {}",
+                   s->remote_address(),
+                   ip_count);
         _client_session_count->set(ip_count);
     }
 }
@@ -818,9 +817,9 @@ void connection_oriented_network::on_client_session_disconnected(rpc_session_ptr
     }
 
     if (r) {
-        LOG_INFO("client session disconnected, remote_server = %s, current_count = %d",
-                 s->remote_address().to_string(),
-                 ip_count);
+        LOG_INFO_F("client session disconnected, remote_server = {}, current_count = {}",
+                   s->remote_address(),
+                   ip_count);
         _client_session_count->set(ip_count);
     }
 }

--- a/src/runtime/rpc/raw_message_parser.cpp
+++ b/src/runtime/rpc/raw_message_parser.cpp
@@ -68,8 +68,8 @@ raw_message_parser::raw_message_parser()
     bool hooked = false;
     static std::atomic_bool s_handler_hooked(false);
     if (s_handler_hooked.compare_exchange_strong(hooked, true)) {
-        LOG_INFO("join point on_rpc_session_disconnected registered to notify disconnect with "
-                 "RPC_CALL_RAW_SESSION_DISCONNECT");
+        LOG_INFO_F("join point on_rpc_session_disconnected registered to notify disconnect with "
+                   "RPC_CALL_RAW_SESSION_DISCONNECT");
         rpc_session::on_rpc_session_disconnected.put_back(
             raw_message_parser::notify_rpc_session_disconnected,
             "notify disconnect with RPC_CALL_RAW_SESSION_DISCONNECT");

--- a/src/runtime/rpc/rpc_engine.cpp
+++ b/src/runtime/rpc/rpc_engine.cpp
@@ -185,9 +185,9 @@ bool rpc_client_matcher::on_recv_reply(network *net, uint64_t key, message_ex *r
 
         // failure injection applied
         if (!call->enqueue(err, reply)) {
-            LOG_INFO("rpc reply %s is dropped (fault inject), trace_id = %016" PRIx64,
-                     reply->header->rpc_name,
-                     reply->header->trace_id);
+            LOG_INFO_F("rpc reply {} is dropped (fault inject), trace_id = {:#018x}",
+                       reply->header->rpc_name,
+                       reply->header->trace_id);
 
             // call network failure model
             net->inject_drop_message(reply, false);
@@ -472,11 +472,11 @@ error_code rpc_engine::start(const service_app_spec &aspec)
                 return ERR_NETWORK_INIT_FAILED;
             pnet[j].reset(net);
 
-            LOG_INFO("[%s] network client started at port %u, channel = %s, fmt = %s ...",
-                     node()->full_name(),
-                     (uint32_t)(cs.port),
-                     cs.channel.to_string(),
-                     client_hdr_format.to_string());
+            LOG_INFO_F("[{}] network client started at port {}, channel = {}, fmt = {} ...",
+                       node()->full_name(),
+                       cs.port,
+                       cs.channel,
+                       client_hdr_format);
         }
     }
 
@@ -511,9 +511,9 @@ error_code rpc_engine::start(const service_app_spec &aspec)
     _local_primary_address = _client_nets[NET_HDR_DSN][0]->address();
     _local_primary_address.set_port(aspec.ports.size() > 0 ? *aspec.ports.begin() : aspec.id);
 
-    LOG_INFO("=== service_node=[%s], primary_address=[%s] ===",
-             _node->full_name(),
-             _local_primary_address.to_string());
+    LOG_INFO_F("=== service_node=[{}], primary_address=[{}] ===",
+               _node->full_name(),
+               _local_primary_address);
 
     _is_running = true;
     return ERR_OK;
@@ -571,9 +571,9 @@ void rpc_engine::on_recv_request(network *net, message_ex *msg, int delay_ms)
 
             // release the task when necessary
             else {
-                LOG_INFO("rpc request %s is dropped (fault inject), trace_id = %016" PRIx64,
-                         msg->header->rpc_name,
-                         msg->header->trace_id);
+                LOG_INFO_F("rpc request {} is dropped (fault inject), trace_id = {:#018x}",
+                           msg->header->rpc_name,
+                           msg->header->trace_id);
 
                 // call network failure model when network is present
                 net->inject_drop_message(msg, false);
@@ -693,9 +693,9 @@ void rpc_engine::call_ip(rpc_address addr,
 
     // join point and possible fault injection
     if (!sp->on_rpc_call.execute(task::get_current_task(), request, call, true)) {
-        LOG_INFO("rpc request %s is dropped (fault inject), trace_id = %016" PRIx64,
-                 request->header->rpc_name,
-                 request->header->trace_id);
+        LOG_INFO_F("rpc request {} is dropped (fault inject), trace_id = {:#018x}",
+                   request->header->rpc_name,
+                   request->header->trace_id);
 
         // call network failure model
         net->inject_drop_message(request, true);

--- a/src/runtime/security/init.cpp
+++ b/src/runtime/security/init.cpp
@@ -55,14 +55,14 @@ bool init(bool is_server)
         LOG_ERROR_F("initialize kerberos failed, with err = {}", err.description());
         return false;
     }
-    LOG_INFO("initialize kerberos succeed");
+    LOG_INFO_F("initialize kerberos succeed");
 
     err = init_sasl(is_server);
     if (!err.is_ok()) {
         LOG_ERROR_F("initialize sasl failed, with err = {}", err.description());
         return false;
     }
-    LOG_INFO("initialize sasl succeed");
+    LOG_INFO_F("initialize sasl succeed");
 
     init_join_point();
     return true;
@@ -75,14 +75,14 @@ bool init_for_zookeeper_client()
         LOG_ERROR_F("initialize kerberos failed, with err = {}", err.description());
         return false;
     }
-    LOG_INFO("initialize kerberos for zookeeper client succeed");
+    LOG_INFO_F("initialize kerberos for zookeeper client succeed");
 
     err = init_sasl(false);
     if (!err.is_ok()) {
         LOG_ERROR_F("initialize sasl failed, with err = {}", err.description());
         return false;
     }
-    LOG_INFO("initialize sasl for zookeeper client succeed");
+    LOG_INFO_F("initialize sasl for zookeeper client succeed");
     return true;
 }
 } // namespace security

--- a/src/runtime/service_api_c.cpp
+++ b/src/runtime/service_api_c.cpp
@@ -429,10 +429,10 @@ bool run(const char *config_file,
     // prepare minimum necessary
     ::dsn::service_engine::instance().init_before_toollets(spec);
 
-    LOG_INFO("process(%ld) start: %" PRIu64 ", date: %s",
-             getpid(),
-             dsn::utils::process_start_millis(),
-             dsn::utils::process_start_date_time_mills());
+    LOG_INFO_F("process({}) start: {}, date: {}",
+               getpid(),
+               dsn::utils::process_start_millis(),
+               dsn::utils::process_start_date_time_mills());
 
     // init toollets
     for (auto it = spec.toollets.begin(); it != spec.toollets.end(); ++it) {

--- a/src/runtime/test/async_call.cpp
+++ b/src/runtime/test/async_call.cpp
@@ -165,12 +165,12 @@ class simple_task : public dsn::raw_task
 public:
     simple_task(dsn::task_code code, const task_handler &h) : dsn::raw_task(code, h, 0, nullptr)
     {
-        LOG_INFO("simple task %p created", this);
+        LOG_INFO_F("simple task {} created", fmt::ptr(this));
         allocate_count++;
     }
     virtual ~simple_task() override
     {
-        LOG_INFO("simple task %p is deallocated", this);
+        LOG_INFO_F("simple task {} is deallocated", fmt::ptr(this));
         allocate_count--;
     }
     static std::atomic_int allocate_count;
@@ -188,12 +188,12 @@ public:
     simple_rpc_response_task(dsn::message_ex *m, const rpc_response_handler &h)
         : dsn::rpc_response_task(m, h)
     {
-        LOG_INFO("simple rpc response task(%p) created", this);
+        LOG_INFO_F("simple rpc response task({}) created", fmt::ptr(this));
         allocate_count++;
     }
     virtual ~simple_rpc_response_task() override
     {
-        LOG_INFO("simple rpc repsonse task(%p) is dealloate", this);
+        LOG_INFO_F("simple rpc repsonse task({}) is dealloate", fmt::ptr(this));
         allocate_count--;
     }
     static std::atomic_int allocate_count;
@@ -247,7 +247,7 @@ TEST(async_call, task_destructor)
     {
         dsn::ref_ptr<simple_task_container> c(new simple_task_container());
         c->t =
-            new simple_task(LPC_TEST_CLIENTLET, [c]() { LOG_INFO("cycle link reference test"); });
+            new simple_task(LPC_TEST_CLIENTLET, [c]() { LOG_INFO_F("cycle link reference test"); });
 
         c->t->enqueue();
         c->t->wait();
@@ -257,7 +257,7 @@ TEST(async_call, task_destructor)
     {
         dsn::ref_ptr<simple_task_container> c(new simple_task_container());
         c->t =
-            new simple_task(LPC_TEST_CLIENTLET, [c]() { LOG_INFO("cycle link reference test"); });
+            new simple_task(LPC_TEST_CLIENTLET, [c]() { LOG_INFO_F("cycle link reference test"); });
 
         ASSERT_TRUE(c->t->cancel(false));
     }

--- a/src/runtime/test/netprovider.cpp
+++ b/src/runtime/test/netprovider.cpp
@@ -75,8 +75,8 @@ public:
 public:
     void change_test_cfg_conn_threshold_per_ip(uint32_t n)
     {
-        LOG_INFO(
-            "change _cfg_conn_threshold_per_ip %u -> %u for test", _cfg_conn_threshold_per_ip, n);
+        LOG_INFO_F(
+            "change _cfg_conn_threshold_per_ip {} -> {} for test", _cfg_conn_threshold_per_ip, n);
         _cfg_conn_threshold_per_ip = n;
     }
 };
@@ -96,7 +96,7 @@ void response_handler(dsn::error_code ec,
         ::dsn::unmarshall(resp, response_string);
         ASSERT_EQ(response_string, request_str);
     } else {
-        LOG_INFO("error msg: %s", ec.to_string());
+        LOG_INFO_F("error msg: {}", ec);
     }
     wait_flag = 1;
 }
@@ -179,11 +179,11 @@ TEST(tools_common, asio_net_provider)
 
     start_result = asio_network2->start(RPC_CHANNEL_TCP, TEST_PORT, false);
     ASSERT_TRUE(start_result == ERR_OK);
-    LOG_INFO("result: %s", start_result.to_string());
+    LOG_INFO_F("result: {}", start_result);
 
     start_result = asio_network2->start(RPC_CHANNEL_TCP, TEST_PORT, false);
     ASSERT_TRUE(start_result == ERR_SERVICE_ALREADY_RUNNING);
-    LOG_INFO("result: %s", start_result.to_string());
+    LOG_INFO_F("result: {}", start_result);
 
     rpc_session_ptr client_session =
         asio_network->create_client_session(rpc_address("localhost", TEST_PORT));
@@ -290,7 +290,7 @@ TEST(tools_common, asio_network_provider_connection_threshold)
 
     // not exceed threshold
     for (int count = 0; count < CONN_THRESHOLD + 2; count++) {
-        LOG_INFO("client # %d", count);
+        LOG_INFO_F("client # {}", count);
         rpc_session_ptr client_session =
             asio_network->create_client_session(rpc_address("localhost", TEST_PORT));
         client_session->connect();
@@ -304,7 +304,7 @@ TEST(tools_common, asio_network_provider_connection_threshold)
     // exceed threshold
     bool reject = false;
     for (int count = 0; count < CONN_THRESHOLD + 2; count++) {
-        LOG_INFO("client # %d", count);
+        LOG_INFO_F("client # {}", count);
         rpc_session_ptr client_session =
             asio_network->create_client_session(rpc_address("localhost", TEST_PORT));
         client_session->connect();

--- a/src/runtime/test/rpc.cpp
+++ b/src/runtime/test/rpc.cpp
@@ -99,7 +99,7 @@ TEST(core, group_address_talk_to_others)
     auto typed_callback = [addr](error_code err_code, const std::string &result) {
         EXPECT_EQ(ERR_OK, err_code);
         dsn::rpc_address addr_got;
-        LOG_INFO("talk to others callback, result: %s", result.c_str());
+        LOG_INFO_F("talk to others callback, result: {}", result);
         EXPECT_TRUE(addr_got.from_string_ipv4(result.c_str()));
         EXPECT_EQ(TEST_PORT_END, addr_got.port());
     };
@@ -120,7 +120,7 @@ TEST(core, group_address_change_leader)
         rpc_err = err_code;
         if (ERR_OK == err_code) {
             ::dsn::rpc_address addr_got;
-            LOG_INFO("talk to others callback, result: %s", result.c_str());
+            LOG_INFO_F("talk to others callback, result: {}", result);
             EXPECT_TRUE(addr_got.from_string_ipv4(result.c_str()));
             EXPECT_EQ(TEST_PORT_END, addr_got.port());
         }
@@ -151,7 +151,7 @@ TEST(core, group_address_change_leader)
                                nullptr,
                                typed_callback);
     resp_task->wait();
-    LOG_INFO("addr.leader=%s", addr.group_address()->leader().to_string());
+    LOG_INFO_F("addr.leader={}", addr.group_address()->leader());
     if (rpc_err == ERR_OK) {
         EXPECT_EQ(TEST_PORT_END, addr.group_address()->leader().port());
     }

--- a/src/runtime/test/test_utils.h
+++ b/src/runtime/test/test_utils.h
@@ -102,16 +102,16 @@ public:
             dsn::rpc_address next_addr = dsn::service_app::primary_address();
             if (next_addr.port() != TEST_PORT_END) {
                 next_addr.assign_ipv4(next_addr.ip(), next_addr.port() + 1);
-                LOG_INFO("test_client_server, talk_to_others: %s", next_addr.to_string());
+                LOG_INFO_F("test_client_server, talk_to_others: {}", next_addr);
                 dsn_rpc_forward(message, next_addr);
             } else {
-                LOG_INFO("test_client_server, talk_to_me: %s", next_addr.to_string());
+                LOG_INFO_F("test_client_server, talk_to_me: {}", next_addr);
                 reply(message, next_addr.to_std_string());
             }
         } else if (command == "expect_no_reply") {
             if (dsn::service_app::primary_address().port() == TEST_PORT_END) {
-                LOG_INFO("test_client_server, talk_with_reply: %s",
-                         dsn::service_app::primary_address().to_std_string().c_str());
+                LOG_INFO_F("test_client_server, talk_with_reply: {}",
+                           dsn::service_app::primary_address());
                 reply(message, dsn::service_app::primary_address().to_std_string());
             }
         } else if (command.substr(0, 5) == "echo ") {

--- a/src/runtime/tool_api.cpp
+++ b/src/runtime/tool_api.cpp
@@ -60,7 +60,7 @@ public:
             err = _node->start_app();
             CHECK_EQ_MSG(err, ERR_OK, "start app failed");
         } else {
-            LOG_INFO("stop app result(%s)", _node->stop_app(_cleanup).to_string());
+            LOG_INFO_F("stop app result({})", _node->stop_app(_cleanup));
         }
     }
 

--- a/src/runtime/tracer.cpp
+++ b/src/runtime/tracer.cpp
@@ -38,37 +38,35 @@ static void tracer_on_task_create(task *caller, task *callee)
     dsn_task_type_t type = callee->spec().type;
     if (TASK_TYPE_RPC_REQUEST == type) {
         rpc_request_task *tsk = (rpc_request_task *)callee;
-        LOG_INFO("%s CREATE, task_id = %016" PRIx64
-                 ", type = %s, rpc_name = %s, trace_id = %016" PRIx64 "",
-                 callee->spec().name.c_str(),
-                 callee->id(),
-                 enum_to_string(type),
-                 tsk->get_request()->header->rpc_name,
-                 tsk->get_request()->header->trace_id);
+        LOG_INFO_F("{} CREATE, task_id = {:#018x}, type = {}, rpc_name = {}, trace_id = {:#018x}",
+                   callee->spec().name,
+                   callee->id(),
+                   enum_to_string(type),
+                   tsk->get_request()->header->rpc_name,
+                   tsk->get_request()->header->trace_id);
     } else if (TASK_TYPE_RPC_RESPONSE == type) {
         rpc_response_task *tsk = (rpc_response_task *)callee;
-        LOG_INFO("%s CREATE, task_id = %016" PRIx64
-                 ", type = %s, rpc_name = %s, trace_id = %016" PRIx64 "",
-                 callee->spec().name.c_str(),
-                 callee->id(),
-                 enum_to_string(type),
-                 tsk->get_request()->header->rpc_name,
-                 tsk->get_request()->header->trace_id);
+        LOG_INFO_F("{} CREATE, task_id = {:#018x}, type = {}, rpc_name = {}, trace_id = {:#018x}",
+                   callee->spec().name,
+                   callee->id(),
+                   enum_to_string(type),
+                   tsk->get_request()->header->rpc_name,
+                   tsk->get_request()->header->trace_id);
     } else {
-        LOG_INFO("%s CREATE, task_id = %016" PRIx64 ", type = %s",
-                 callee->spec().name.c_str(),
-                 callee->id(),
-                 enum_to_string(type));
+        LOG_INFO_F("{} CREATE, task_id = {:#018x}, type = {}",
+                   callee->spec().name,
+                   callee->id(),
+                   enum_to_string(type));
     }
 }
 
 static void tracer_on_task_enqueue(task *caller, task *callee)
 {
-    LOG_INFO("%s ENQUEUE, task_id = %016" PRIx64 ", delay = %d ms, queue size = %d",
-             callee->spec().name.c_str(),
-             callee->id(),
-             callee->delay_milliseconds(),
-             tls_dsn.last_worker_queue_size);
+    LOG_INFO_F("{} ENQUEUE, task_id = {:#018x}, delay = {} ms, queue size = {}",
+               callee->spec().name,
+               callee->id(),
+               callee->delay_milliseconds(),
+               tls_dsn.last_worker_queue_size);
 }
 
 static void tracer_on_task_begin(task *this_)
@@ -76,26 +74,25 @@ static void tracer_on_task_begin(task *this_)
     switch (this_->spec().type) {
     case dsn_task_type_t::TASK_TYPE_COMPUTE:
     case dsn_task_type_t::TASK_TYPE_AIO:
-        LOG_INFO(
-            "%s EXEC BEGIN, task_id = %016" PRIx64 "", this_->spec().name.c_str(), this_->id());
+        LOG_INFO_F("{} EXEC BEGIN, task_id = {:#018x}", this_->spec().name, this_->id());
         break;
     case dsn_task_type_t::TASK_TYPE_RPC_REQUEST: {
         rpc_request_task *tsk = (rpc_request_task *)this_;
-        LOG_INFO("%s EXEC BEGIN, task_id = %016" PRIx64 ", %s => %s, trace_id = %016" PRIx64 "",
-                 this_->spec().name.c_str(),
-                 this_->id(),
-                 tsk->get_request()->header->from_address.to_string(),
-                 tsk->get_request()->to_address.to_string(),
-                 tsk->get_request()->header->trace_id);
+        LOG_INFO_F("{} EXEC BEGIN, task_id = {:#018x}, {} => {}, trace_id = {:#018x}",
+                   this_->spec().name,
+                   this_->id(),
+                   tsk->get_request()->header->from_address,
+                   tsk->get_request()->to_address,
+                   tsk->get_request()->header->trace_id);
     } break;
     case dsn_task_type_t::TASK_TYPE_RPC_RESPONSE: {
         rpc_response_task *tsk = (rpc_response_task *)this_;
-        LOG_INFO("%s EXEC BEGIN, task_id = %016" PRIx64 ", %s => %s, trace_id = %016" PRIx64 "",
-                 this_->spec().name.c_str(),
-                 this_->id(),
-                 tsk->get_request()->to_address.to_string(),
-                 tsk->get_request()->header->from_address.to_string(),
-                 tsk->get_request()->header->trace_id);
+        LOG_INFO_F("{} EXEC BEGIN, task_id = {:#018x}, {} => {}, trace_id = {:#018x}",
+                   this_->spec().name,
+                   this_->id(),
+                   tsk->get_request()->to_address,
+                   tsk->get_request()->header->from_address,
+                   tsk->get_request()->header->trace_id);
     } break;
     default:
         break;
@@ -104,15 +101,15 @@ static void tracer_on_task_begin(task *this_)
 
 static void tracer_on_task_end(task *this_)
 {
-    LOG_INFO("%s EXEC END, task_id = %016" PRIx64 ", err = %s",
-             this_->spec().name.c_str(),
-             this_->id(),
-             this_->error().to_string());
+    LOG_INFO_F("{} EXEC END, task_id = {:#018x}, err = {}",
+               this_->spec().name,
+               this_->id(),
+               this_->error());
 }
 
 static void tracer_on_task_cancelled(task *this_)
 {
-    LOG_INFO("%s CANCELLED, task_id = %016" PRIx64 "", this_->spec().name.c_str(), this_->id());
+    LOG_INFO_F("{} CANCELLED, task_id = {:#018x}", this_->spec().name, this_->id());
 }
 
 static void tracer_on_task_wait_pre(task *caller, task *callee, uint32_t timeout_ms) {}
@@ -124,46 +121,46 @@ static void tracer_on_task_cancel_post(task *caller, task *callee, bool succ) {}
 // return true means continue, otherwise early terminate with task::set_error_code
 static void tracer_on_aio_call(task *caller, aio_task *callee)
 {
-    LOG_INFO("%s AIO.CALL, task_id = %016" PRIx64 ", offset = %" PRIu64 ", size = %d",
-             callee->spec().name.c_str(),
-             callee->id(),
-             callee->get_aio_context()->file_offset,
-             callee->get_aio_context()->buffer_size);
+    LOG_INFO_F("{} AIO.CALL, task_id = {:#018x}, offset = {}, size = {}",
+               callee->spec().name,
+               callee->id(),
+               callee->get_aio_context()->file_offset,
+               callee->get_aio_context()->buffer_size);
 }
 
 static void tracer_on_aio_enqueue(aio_task *this_)
 {
-    LOG_INFO("%s AIO.ENQUEUE, task_id = %016" PRIx64 ", queue size = %d",
-             this_->spec().name.c_str(),
-             this_->id(),
-             tls_dsn.last_worker_queue_size);
+    LOG_INFO_F("{} AIO.ENQUEUE, task_id = {:#018x}, queue size = {}",
+               this_->spec().name,
+               this_->id(),
+               tls_dsn.last_worker_queue_size);
 }
 
 // return true means continue, otherwise early terminate with task::set_error_code
 static void tracer_on_rpc_call(task *caller, message_ex *req, rpc_response_task *callee)
 {
     message_header &hdr = *req->header;
-    LOG_INFO("%s RPC.CALL: %s => %s, trace_id = %016" PRIx64 ", callback_task = %016" PRIx64
-             ", timeout = %d ms",
-             hdr.rpc_name,
-             req->header->from_address.to_string(),
-             req->to_address.to_string(),
-             hdr.trace_id,
-             callee ? callee->id() : 0,
-             hdr.client.timeout_ms);
+    LOG_INFO_F(
+        "{} RPC.CALL: {} => {}, trace_id = {:#018x}, callback_task = {:#018x}, timeout = {} ms",
+        hdr.rpc_name,
+        req->header->from_address,
+        req->to_address,
+        hdr.trace_id,
+        callee ? callee->id() : 0,
+        hdr.client.timeout_ms);
 }
 
 static void tracer_on_rpc_request_enqueue(rpc_request_task *callee)
 {
-    LOG_INFO("%s RPC.REQUEST.ENQUEUE (0x%p), task_id = %016" PRIx64
-             ", %s => %s, trace_id = %016" PRIx64 ", queue size = %d",
-             callee->spec().name.c_str(),
-             callee,
-             callee->id(),
-             callee->get_request()->header->from_address.to_string(),
-             callee->get_request()->to_address.to_string(),
-             callee->get_request()->header->trace_id,
-             tls_dsn.last_worker_queue_size);
+    LOG_INFO_F("{} RPC.REQUEST.ENQUEUE ({}), task_id = {:#018x}, {} => {}, trace_id = {:#018x}, "
+               "queue size = {}",
+               callee->spec().name,
+               fmt::ptr(callee),
+               callee->id(),
+               callee->get_request()->header->from_address,
+               callee->get_request()->to_address,
+               callee->get_request()->header->trace_id,
+               tls_dsn.last_worker_queue_size);
 }
 
 // return true means continue, otherwise early terminate with task::set_error_code
@@ -171,30 +168,30 @@ static void tracer_on_rpc_reply(task *caller, message_ex *msg)
 {
     message_header &hdr = *msg->header;
 
-    LOG_INFO("%s RPC.REPLY: %s => %s, trace_id = %016" PRIx64 "",
-             hdr.rpc_name,
-             msg->header->from_address.to_string(),
-             msg->to_address.to_string(),
-             hdr.trace_id);
+    LOG_INFO_F("{} RPC.REPLY: {} => {}, trace_id = {:#018x}",
+               hdr.rpc_name,
+               msg->header->from_address,
+               msg->to_address,
+               hdr.trace_id);
 }
 
 static void tracer_on_rpc_response_enqueue(rpc_response_task *resp)
 {
-    LOG_INFO("%s RPC.RESPONSE.ENQUEUE, task_id = %016" PRIx64 ", %s => %s, trace_id = %016" PRIx64
-             ", queue size = %d",
-             resp->spec().name.c_str(),
-             resp->id(),
-             resp->get_request()->to_address.to_string(),
-             resp->get_request()->header->from_address.to_string(),
-             resp->get_request()->header->trace_id,
-             tls_dsn.last_worker_queue_size);
+    LOG_INFO_F("{} RPC.RESPONSE.ENQUEUE, task_id = {:#018x}, {} => {}, trace_id = {:#018x}, queue "
+               "size = {}",
+               resp->spec().name,
+               resp->id(),
+               resp->get_request()->to_address,
+               resp->get_request()->header->from_address,
+               resp->get_request()->header->trace_id,
+               tls_dsn.last_worker_queue_size);
 }
 
 static void tracer_on_rpc_create_response(message_ex *req, message_ex *resp)
 {
-    LOG_INFO("%s RPC.CREATE.RESPONSE, trace_id = %016" PRIx64 "",
-             resp->header->rpc_name,
-             resp->header->trace_id);
+    LOG_INFO_F("{} RPC.CREATE.RESPONSE, trace_id = {:#018x}",
+               resp->header->rpc_name,
+               resp->header->trace_id);
 }
 
 enum logged_event_t

--- a/src/server/available_detector.cpp
+++ b/src/server/available_detector.cpp
@@ -270,20 +270,20 @@ bool available_detector::generate_hash_keys()
 void available_detector::on_detect(int32_t idx)
 {
     if (idx == 0) {
-        LOG_INFO("detecting table[%s] with app_id[%d] and partition_count[%d] on cluster[%s], "
-                 "recent_day_detect_times(%" PRId64 "), recent_day_fail_times(%" PRId64 "), "
-                 "recent_hour_detect_times(%" PRId64 "), recent_hour_fail_times(%" PRId64 ") "
-                 "recent_minute_detect_times(%" PRId64 "), recent_minute_fail_times(%" PRId64 ")",
-                 _app_name.c_str(),
-                 _app_id,
-                 _partition_count,
-                 _cluster_name.c_str(),
-                 _recent_day_detect_times.load(),
-                 _recent_day_fail_times.load(),
-                 _recent_hour_detect_times.load(),
-                 _recent_hour_fail_times.load(),
-                 _recent_minute_detect_times.load(),
-                 _recent_minute_fail_times.load());
+        LOG_INFO_F("detecting table[{}] with app_id[{}] and partition_count[{}] on cluster[{}], "
+                   "recent_day_detect_times({}), recent_day_fail_times({}), "
+                   "recent_hour_detect_times({}), recent_hour_fail_times({}) "
+                   "recent_minute_detect_times({}), recent_minute_fail_times({})",
+                   _app_name,
+                   _app_id,
+                   _partition_count,
+                   _cluster_name,
+                   _recent_day_detect_times,
+                   _recent_day_fail_times,
+                   _recent_hour_detect_times,
+                   _recent_hour_fail_times,
+                   _recent_minute_detect_times,
+                   _recent_minute_fail_times);
     }
     LOG_DEBUG_F("available_detector begin to detect partition[{}] of table[{}] with id[{}] on the "
                 "cluster[{}]",
@@ -362,15 +362,15 @@ void available_detector::check_and_send_email(std::atomic<int> *cnt, int32_t idx
         }
     }
     if (send_email) {
-        LOG_INFO("start to send alert email, partition_index = %d", idx);
+        LOG_INFO_F("start to send alert email, partition_index = {}", idx);
         if (_send_alert_email_cmd.empty()) {
-            LOG_INFO("ignore sending alert email because email address is not set, "
-                     "partition_index = %d",
-                     idx);
+            LOG_INFO_F("ignore sending alert email because email address is not set, "
+                       "partition_index = {}",
+                       idx);
         } else {
             int r = system((_send_alert_email_cmd + std::to_string(idx)).c_str());
             if (r == 0) {
-                LOG_INFO("send alert email done, partition_index = %d", idx);
+                LOG_INFO_F("send alert email done, partition_index = {}", idx);
             } else {
                 LOG_ERROR("send alert email failed, partition_index = %d, "
                           "command_return = %d",
@@ -383,7 +383,7 @@ void available_detector::check_and_send_email(std::atomic<int> *cnt, int32_t idx
 
 void available_detector::on_day_report()
 {
-    LOG_INFO("start to report on new day, last_day = %s", _old_day.c_str());
+    LOG_INFO_F("start to report on new day, last_day = {}", _old_day);
     int64_t detect_times = _recent_day_detect_times.fetch_and(0);
     int64_t fail_times = _recent_day_fail_times.fetch_and(0);
     int64_t succ_times = std::max<int64_t>(0L, detect_times - fail_times);
@@ -402,23 +402,23 @@ void available_detector::on_day_report()
     _pfc_fail_times_day->set(fail_times);
     _pfc_available_day->set(available);
 
-    LOG_INFO("start to send availability email, date = %s", _old_day.c_str());
+    LOG_INFO_F("start to send availability email, date = {}", _old_day);
     if (_send_availability_info_email_cmd.empty()) {
-        LOG_INFO("ignore sending availability email because email address is not set, "
-                 "date = %s, total_detect_times = %u, total_fail_times = %u",
-                 _old_day.c_str(),
-                 detect_times,
-                 fail_times);
+        LOG_INFO_F("ignore sending availability email because email address is not set, "
+                   "date = {}, total_detect_times = {}, total_fail_times = {}",
+                   _old_day,
+                   detect_times,
+                   fail_times);
     } else {
         int r = system((_send_availability_info_email_cmd + std::to_string(detect_times) + " " +
                         std::to_string(fail_times) + " " + _old_day)
                            .c_str());
         if (r == 0) {
-            LOG_INFO("send availability email done, date = %s, "
-                     "total_detect_times = %u, total_fail_times = %u",
-                     _old_day.c_str(),
-                     detect_times,
-                     fail_times);
+            LOG_INFO_F("send availability email done, date = {}, "
+                       "total_detect_times = {}, total_fail_times = {}",
+                       _old_day,
+                       detect_times,
+                       fail_times);
         } else {
             LOG_ERROR("send availability email fail, date = %s, "
                       "total_detect_times = %u, total_fail_times = %u, command_return = %d",
@@ -434,7 +434,7 @@ void available_detector::on_day_report()
 
 void available_detector::on_hour_report()
 {
-    LOG_INFO("start to report on new hour, last_hour = %s", _old_hour.c_str());
+    LOG_INFO_F("start to report on new hour, last_hour = {}", _old_hour);
     int64_t detect_times = _recent_hour_detect_times.fetch_and(0);
     int64_t fail_times = _recent_hour_fail_times.fetch_and(0);
     int64_t succ_times = std::max<int64_t>(0L, detect_times - fail_times);
@@ -458,7 +458,7 @@ void available_detector::on_hour_report()
 
 void available_detector::on_minute_report()
 {
-    LOG_INFO("start to report on new minute, last_minute = %s", _old_minute.c_str());
+    LOG_INFO_F("start to report on new minute, last_minute = {}", _old_minute);
     int64_t detect_times = _recent_minute_detect_times.fetch_and(0);
     int64_t fail_times = _recent_minute_fail_times.fetch_and(0);
     int64_t succ_times = std::max<int64_t>(0L, detect_times - fail_times);

--- a/src/server/compaction_operation.cpp
+++ b/src/server/compaction_operation.cpp
@@ -97,7 +97,7 @@ bool update_ttl::filter(dsn::string_view hash_key,
         new_ts = value - pegasus::utils::epoch_begin;
         break;
     default:
-        LOG_INFO("invalid update ttl operation type");
+        LOG_INFO_F("invalid update ttl operation type");
         return false;
     }
 
@@ -160,7 +160,7 @@ compaction_operations create_compaction_operations(const std::string &json, uint
     internal::json_helper compaction;
     if (!dsn::json::json_forwarder<internal::json_helper>::decode(
             dsn::blob::create_from_bytes(json.data(), json.size()), compaction)) {
-        LOG_INFO("invalid user specified compaction format");
+        LOG_INFO_F("invalid user specified compaction format");
         return res;
     }
 

--- a/src/server/hotspot_partition_calculator.cpp
+++ b/src/server/hotspot_partition_calculator.cpp
@@ -107,7 +107,7 @@ void hotspot_partition_calculator::stat_histories_analyse(uint32_t data_type,
         }
     }
     if (sample_count <= 1) {
-        LOG_INFO("_partitions_stat_histories size <= 1, not enough data for calculation");
+        LOG_INFO_F("_partitions_stat_histories size <= 1, not enough data for calculation");
         return;
     }
     table_qps_avg = table_qps_sum / sample_count;

--- a/src/server/info_collector.cpp
+++ b/src/server/info_collector.cpp
@@ -140,7 +140,7 @@ void info_collector::stop() { _tracker.cancel_outstanding_tasks(); }
 
 void info_collector::on_app_stat()
 {
-    LOG_INFO("start to stat apps");
+    LOG_INFO_F("start to stat apps");
     std::map<std::string, std::vector<row_data>> all_rows;
     if (!get_app_partition_stat(_shell_context.get(), all_rows)) {
         LOG_ERROR("call get_app_stat() failed");
@@ -257,7 +257,7 @@ info_collector::app_stat_counters *info_collector::get_app_counters(const std::s
 
 void info_collector::on_capacity_unit_stat(int remaining_retry_count)
 {
-    LOG_INFO("start to stat capacity unit, remaining_retry_count = %d", remaining_retry_count);
+    LOG_INFO_F("start to stat capacity unit, remaining_retry_count = {}", remaining_retry_count);
     std::vector<node_capacity_unit_stat> nodes_stat;
     if (!get_capacity_unit_stat(_shell_context.get(), nodes_stat)) {
         if (remaining_retry_count > 0) {
@@ -304,7 +304,7 @@ bool info_collector::has_capacity_unit_updated(const std::string &node_address,
 
 void info_collector::on_storage_size_stat(int remaining_retry_count)
 {
-    LOG_INFO("start to stat storage size, remaining_retry_count = %d", remaining_retry_count);
+    LOG_INFO_F("start to stat storage size, remaining_retry_count = {}", remaining_retry_count);
     app_storage_size_stat st_stat;
     if (!get_storage_size_stat(_shell_context.get(), st_stat)) {
         if (remaining_retry_count > 0) {

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -82,8 +82,7 @@ int main(int argc, char **argv)
             dsn_exit(0);
         }
     }
-    LOG_INFO(
-        "pegasus server starting, pid(%d), version(%s)", (int)getpid(), pegasus_server_rcsid());
+    LOG_INFO_F("pegasus server starting, pid({}), version({})", getpid(), pegasus_server_rcsid());
     dsn_app_registration_pegasus();
 
     std::unique_ptr<command_deregister> server_info_cmd =

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -1823,8 +1823,7 @@ void pegasus_server_impl::cancel_background_work(bool wait)
         _pfc_rdb_memtable_mem_usage->set(0);
     }
 
-    LOG_INFO_F(
-        "{}: close app succeed, clear_state = {}", replica_name(), clear_state ? "true" : "false");
+    LOG_INFO_PREFIX("close app succeed, clear_state = {}", clear_state ? "true" : "false");
     return ::dsn::ERR_OK;
 }
 
@@ -2568,8 +2567,7 @@ pegasus_server_impl::get_restore_dir_from_env(const std::map<std::string, std::s
 
     it = env_kvs.find(ROCKSDB_ENV_RESTORE_BACKUP_ID);
     if (it != env_kvs.end()) {
-        LOG_INFO_F(
-            "{}: found {} in envs: {}", replica_name(), ROCKSDB_ENV_RESTORE_BACKUP_ID, it->second);
+        LOG_INFO_PREFIX("found {} in envs: {}", ROCKSDB_ENV_RESTORE_BACKUP_ID, it->second);
         os << it->second;
     } else {
         return res;
@@ -3123,8 +3121,7 @@ bool pegasus_server_impl::set_options(
     }
     rocksdb::Status status = _db->SetOptions(_data_cf, new_options);
     if (status == rocksdb::Status::OK()) {
-        LOG_INFO_F(
-            "{}: rocksdb set options returns {}: {}", replica_name(), status.ToString(), oss.str());
+        LOG_INFO_PREFIX("rocksdb set options returns {}: {}", status.ToString(), oss.str());
         return true;
     } else {
         LOG_ERROR("%s: rocksdb set options returns %s: {%s}",

--- a/src/server/pegasus_server_impl.cpp
+++ b/src/server/pegasus_server_impl.cpp
@@ -96,7 +96,7 @@ void pegasus_server_impl::parse_checkpoints()
         if (chkpt_init_from_dir(d1.c_str(), ci)) {
             _checkpoints.push_back(ci);
         } else if (d1.find("checkpoint") != std::string::npos) {
-            LOG_INFO("%s: invalid checkpoint directory %s, remove it", replica_name(), d.c_str());
+            LOG_INFO_PREFIX("invalid checkpoint directory {}, remove it", d);
             ::dsn::utils::filesystem::remove_path(d);
             if (!::dsn::utils::filesystem::remove_path(d)) {
                 LOG_ERROR(
@@ -165,9 +165,8 @@ void pegasus_server_impl::gc_checkpoints(bool force_reserve_one)
     }
     if (max_del_d == -1) {
         // no checkpoint to delete
-        LOG_INFO("%s: no checkpoint to garbage collection, checkpoints_count = %d",
-                 replica_name(),
-                 (int)temp_list.size());
+        LOG_INFO_PREFIX("no checkpoint to garbage collection, checkpoints_count = {}",
+                        temp_list.size());
         return;
     }
     std::list<int64_t> to_delete_list;
@@ -206,9 +205,7 @@ void pegasus_server_impl::gc_checkpoints(bool force_reserve_one)
             ::dsn::utils::filesystem::path_combine(data_dir(), chkpt_get_dir_name(del_d));
         if (::dsn::utils::filesystem::directory_exists(cpt_dir)) {
             if (::dsn::utils::filesystem::remove_path(cpt_dir)) {
-                LOG_INFO("%s: checkpoint directory %s removed by garbage collection",
-                         replica_name(),
-                         cpt_dir.c_str());
+                LOG_INFO_PREFIX("checkpoint directory {} removed by garbage collection", cpt_dir);
             } else {
                 LOG_ERROR("%s: checkpoint directory %s remove failed by garbage collection",
                           replica_name(),
@@ -216,9 +213,8 @@ void pegasus_server_impl::gc_checkpoints(bool force_reserve_one)
                 put_back_list.push_back(del_d);
             }
         } else {
-            LOG_INFO("%s: checkpoint directory %s does not exist, ignored by garbage collection",
-                     replica_name(),
-                     cpt_dir.c_str());
+            LOG_INFO_PREFIX("checkpoint directory {} does not exist, ignored by garbage collection",
+                            cpt_dir);
         }
     }
 
@@ -247,12 +243,11 @@ void pegasus_server_impl::gc_checkpoints(bool force_reserve_one)
         }
     }
 
-    LOG_INFO("%s: after checkpoint garbage collection, checkpoints_count = %d, "
-             "min_checkpoint = %" PRId64 ", max_checkpoint = %" PRId64,
-             replica_name(),
-             checkpoints_count,
-             min_d,
-             max_d);
+    LOG_INFO_PREFIX("after checkpoint garbage collection, checkpoints_count = {}, min_checkpoint = "
+                    "{}, max_checkpoint = {}",
+                    checkpoints_count,
+                    min_d,
+                    max_d);
 }
 
 int pegasus_server_impl::on_batched_write_requests(int64_t decree,
@@ -1828,8 +1823,8 @@ void pegasus_server_impl::cancel_background_work(bool wait)
         _pfc_rdb_memtable_mem_usage->set(0);
     }
 
-    LOG_INFO(
-        "%s: close app succeed, clear_state = %s", replica_name(), clear_state ? "true" : "false");
+    LOG_INFO_F(
+        "{}: close app succeed, clear_state = {}", replica_name(), clear_state ? "true" : "false");
     return ::dsn::ERR_OK;
 }
 
@@ -2151,10 +2146,8 @@ private:
     state.from_decree_excluded = 0;
     state.to_decree_included = ci;
 
-    LOG_INFO("%s: get checkpoint succeed, from_decree_excluded = 0, to_decree_included = %" PRId64
-             "",
-             replica_name(),
-             state.to_decree_included);
+    LOG_INFO_PREFIX("get checkpoint succeed, from_decree_excluded = 0, to_decree_included = {}",
+                    state.to_decree_included);
     return ::dsn::ERR_OK;
 }
 
@@ -2225,7 +2218,7 @@ pegasus_server_impl::storage_apply_checkpoint(chkpt_apply_mode mode,
 
         err = start(0, nullptr);
     } else {
-        LOG_INFO("%s: apply empty checkpoint, create new rocksdb", replica_name());
+        LOG_INFO_PREFIX("apply empty checkpoint, create new rocksdb");
         err = start(0, nullptr);
     }
 
@@ -2237,9 +2230,7 @@ pegasus_server_impl::storage_apply_checkpoint(chkpt_apply_mode mode,
     CHECK(_is_open, "");
     CHECK_EQ(ci, last_durable_decree());
 
-    LOG_INFO("%s: apply checkpoint succeed, last_durable_decree = %" PRId64,
-             replica_name(),
-             last_durable_decree());
+    LOG_INFO_PREFIX("apply checkpoint succeed, last_durable_decree = {}", last_durable_decree());
     return ::dsn::ERR_OK;
 }
 
@@ -2563,16 +2554,13 @@ pegasus_server_impl::get_restore_dir_from_env(const std::map<std::string, std::s
 
     auto it = env_kvs.find(ROCKSDB_ENV_RESTORE_FORCE_RESTORE);
     if (it != env_kvs.end()) {
-        LOG_INFO("%s: found %s in envs", replica_name(), ROCKSDB_ENV_RESTORE_FORCE_RESTORE.c_str());
+        LOG_INFO_PREFIX("found {} in envs", ROCKSDB_ENV_RESTORE_FORCE_RESTORE);
         res.second = true;
     }
 
     it = env_kvs.find(ROCKSDB_ENV_RESTORE_POLICY_NAME);
     if (it != env_kvs.end()) {
-        LOG_INFO("%s: found %s in envs: %s",
-                 replica_name(),
-                 ROCKSDB_ENV_RESTORE_POLICY_NAME.c_str(),
-                 it->second.c_str());
+        LOG_INFO_PREFIX("found {} in envs: {}", ROCKSDB_ENV_RESTORE_POLICY_NAME, it->second);
         os << it->second << ".";
     } else {
         return res;
@@ -2580,10 +2568,8 @@ pegasus_server_impl::get_restore_dir_from_env(const std::map<std::string, std::s
 
     it = env_kvs.find(ROCKSDB_ENV_RESTORE_BACKUP_ID);
     if (it != env_kvs.end()) {
-        LOG_INFO("%s: found %s in envs: %s",
-                 replica_name(),
-                 ROCKSDB_ENV_RESTORE_BACKUP_ID.c_str(),
-                 it->second.c_str());
+        LOG_INFO_F(
+            "{}: found {} in envs: {}", replica_name(), ROCKSDB_ENV_RESTORE_BACKUP_ID, it->second);
         os << it->second;
     } else {
         return res;
@@ -3109,10 +3095,8 @@ void pegasus_server_impl::recalculate_data_cf_options(
     }
     if (new_options.size() > 0) {
         if (set_options(new_options)) {
-            LOG_INFO_PREFIX(
-                "{}: recalculate the value of the options related to usage scenario \"{}\"",
-                replica_name(),
-                _usage_scenario);
+            LOG_INFO_PREFIX("recalculate the value of the options related to usage scenario \"{}\"",
+                            _usage_scenario);
         }
     }
     _table_data_cf_opts_recalculated = true;
@@ -3139,10 +3123,8 @@ bool pegasus_server_impl::set_options(
     }
     rocksdb::Status status = _db->SetOptions(_data_cf, new_options);
     if (status == rocksdb::Status::OK()) {
-        LOG_INFO("%s: rocksdb set options returns %s: {%s}",
-                 replica_name(),
-                 status.ToString().c_str(),
-                 oss.str().c_str());
+        LOG_INFO_F(
+            "{}: rocksdb set options returns {}: {}", replica_name(), status.ToString(), oss.str());
         return true;
     } else {
         LOG_ERROR("%s: rocksdb set options returns %s: {%s}",
@@ -3242,9 +3224,8 @@ bool pegasus_server_impl::release_storage_after_manual_compact()
     LOG_INFO_PREFIX("start async_checkpoint");
     start_time = dsn_now_ms();
     ::dsn::error_code err = async_checkpoint(false);
-    LOG_INFO_PREFIX("finish async_checkpoint, return = {}, time_used = {}ms",
-                    err.to_string(),
-                    dsn_now_ms() - start_time);
+    LOG_INFO_PREFIX(
+        "finish async_checkpoint, return = {}, time_used = {}ms", err, dsn_now_ms() - start_time);
 
     // gc checkpoints
     LOG_INFO_PREFIX("start gc_checkpoints");

--- a/src/test/kill_test/data_verifier.cpp
+++ b/src/test/kill_test/data_verifier.cpp
@@ -124,7 +124,7 @@ void do_set(int thread_id)
                        thread_id,
                        id,
                        try_count,
-                       (cur_time - last_time),
+                       cur_time - last_time,
                        info.app_id,
                        info.partition_index,
                        info.decree,

--- a/src/test/kill_test/data_verifier.cpp
+++ b/src/test/kill_test/data_verifier.cpp
@@ -119,33 +119,33 @@ void do_set(int thread_id)
             client->set(hash_key, sort_key, value, set_and_get_timeout_milliseconds, 0, &info);
         if (ret == PERR_OK) {
             long cur_time = get_time();
-            LOG_INFO("SetThread[%d]: set succeed: id=%lld, try=%d, time=%ld (gpid=%d.%d, "
-                     "decree=%lld, server=%s)",
-                     thread_id,
-                     id,
-                     try_count,
-                     (cur_time - last_time),
-                     info.app_id,
-                     info.partition_index,
-                     info.decree,
-                     info.server.c_str());
+            LOG_INFO_F("SetThread[{}]: set succeed: id={}, try={}, time={} (gpid={}.{}, decree={}, "
+                       "server={})",
+                       thread_id,
+                       id,
+                       try_count,
+                       (cur_time - last_time),
+                       info.app_id,
+                       info.partition_index,
+                       info.decree,
+                       info.server);
             stat_time[stat_count++] = cur_time - last_time;
             if (stat_count == stat_batch) {
                 std::sort(stat_time.begin(), stat_time.end());
                 long total_time = 0;
                 for (auto t : stat_time)
                     total_time += t;
-                LOG_INFO("SetThread[%d]: set statistics: count=%lld, min=%lld, P90=%lld, P99=%lld, "
-                         "P999=%lld, P9999=%lld, max=%lld, avg=%lld",
-                         thread_id,
-                         stat_count,
-                         stat_time[stat_min_pos],
-                         stat_time[stat_p90_pos],
-                         stat_time[stat_p99_pos],
-                         stat_time[stat_p999_pos],
-                         stat_time[stat_p9999_pos],
-                         stat_time[stat_max_pos],
-                         total_time / stat_batch);
+                LOG_INFO_F("SetThread[{}]: set statistics: count={}, min={}, P90={}, P99={}, "
+                           "P999={}, P9999={}, max={}, avg={}",
+                           thread_id,
+                           stat_count,
+                           stat_time[stat_min_pos],
+                           stat_time[stat_p90_pos],
+                           stat_time[stat_p99_pos],
+                           stat_time[stat_p999_pos],
+                           stat_time[stat_p9999_pos],
+                           stat_time[stat_max_pos],
+                           total_time / stat_batch);
                 stat_count = 0;
             }
             last_time = cur_time;
@@ -174,8 +174,8 @@ void do_set(int thread_id)
 // - loop from range [start_id, end_id]
 void do_get_range(int thread_id, int round_id, long long start_id, long long end_id)
 {
-    LOG_INFO(
-        "GetThread[%d]: round(%d): start get range [%u,%u]", thread_id, round_id, start_id, end_id);
+    LOG_INFO_F(
+        "GetThread[{}]: round({}): start get range [{},{}]", thread_id, round_id, start_id, end_id);
     char buf[1024];
     std::string hash_key;
     std::string sort_key;
@@ -244,17 +244,17 @@ void do_get_range(int thread_id, int round_id, long long start_id, long long end
                     long total_time = 0;
                     for (auto t : stat_time)
                         total_time += t;
-                    LOG_INFO("GetThread[%d]: get statistics: count=%lld, min=%lld, P90=%lld, "
-                             "P99=%lld, P999=%lld, P9999=%lld, max=%lld, avg=%lld",
-                             thread_id,
-                             stat_count,
-                             stat_time[stat_min_pos],
-                             stat_time[stat_p90_pos],
-                             stat_time[stat_p99_pos],
-                             stat_time[stat_p999_pos],
-                             stat_time[stat_p9999_pos],
-                             stat_time[stat_max_pos],
-                             total_time / stat_batch);
+                    LOG_INFO_F("GetThread[{}]: get statistics: count={}, min={}, P90={}, "
+                               "P99={}, P999={}, P9999={}, max={}, avg={}",
+                               thread_id,
+                               stat_count,
+                               stat_time[stat_min_pos],
+                               stat_time[stat_p90_pos],
+                               stat_time[stat_p99_pos],
+                               stat_time[stat_p999_pos],
+                               stat_time[stat_p9999_pos],
+                               stat_time[stat_max_pos],
+                               total_time / stat_batch);
                     stat_count = 0;
                 }
             }
@@ -279,11 +279,11 @@ void do_get_range(int thread_id, int round_id, long long start_id, long long end
             }
         }
     }
-    LOG_INFO("GetThread[%d]: round(%d): finish get range [%u,%u]",
-             thread_id,
-             round_id,
-             start_id,
-             end_id);
+    LOG_INFO_F("GetThread[{}]: round({}): finish get range [{},{}]",
+               thread_id,
+               round_id,
+               start_id,
+               end_id);
 }
 
 void do_check(int thread_count)
@@ -295,7 +295,7 @@ void do_check(int thread_count)
             sleep(1);
             continue;
         }
-        LOG_INFO("CheckThread: round(%d): start check round, range_end=%lld", round_id, range_end);
+        LOG_INFO_F("CheckThread: round({}): start check round, range_end={}", round_id, range_end);
         long start_time = get_time();
         std::vector<std::thread> worker_threads;
         long long piece_count = range_end / thread_count;
@@ -308,8 +308,8 @@ void do_check(int thread_count)
             t.join();
         }
         long finish_time = get_time();
-        LOG_INFO(
-            "CheckThread: round(%d): finish check round, range_end=%lld, total_time=%ld seconds",
+        LOG_INFO_F(
+            "CheckThread: round({}): finish check round, range_end={}, total_time={} seconds",
             round_id,
             range_end,
             (finish_time - start_time) / 1000000);
@@ -320,10 +320,10 @@ void do_check(int thread_count)
             sprintf(buf, "%lld", range_end);
             int ret = client->set(check_max_key, "", buf, set_and_get_timeout_milliseconds);
             if (ret == PERR_OK) {
-                LOG_INFO("CheckThread: round(%d): update \"%s\" succeed: check_max=%lld",
-                         round_id,
-                         check_max_key,
-                         range_end);
+                LOG_INFO_F("CheckThread: round({}): update \"{}\" succeed: check_max={}",
+                           round_id,
+                           check_max_key,
+                           range_end);
                 break;
             } else {
                 LOG_ERROR("CheckThread: round(%d): update \"%s\" failed: check_max=%lld, ret=%d, "
@@ -358,10 +358,10 @@ void do_mark()
         int ret = client->set(set_next_key, "", value, set_and_get_timeout_milliseconds);
         if (ret == PERR_OK) {
             long cur_time = get_time();
-            LOG_INFO("MarkThread: update \"%s\" succeed: set_next=%lld, time=%ld",
-                     set_next_key,
-                     new_id,
-                     (cur_time - last_time));
+            LOG_INFO_F("MarkThread: update \"{}\" succeed: set_next={}, time={}",
+                       set_next_key,
+                       new_id,
+                       cur_time - last_time);
             old_id = new_id;
         } else {
             LOG_ERROR("MarkThread: update \"%s\" failed: set_next=%lld, ret=%d, error=%s",
@@ -416,11 +416,11 @@ void verifier_start()
                           set_next_value.c_str());
                 exit(-1);
             }
-            LOG_INFO("MainThread: read \"%s\" succeed: value=%lld", set_next_key, i);
+            LOG_INFO_F("MainThread: read \"{}\" succeed: value={}", set_next_key, i);
             set_next.store(i);
             break;
         } else if (ret == PERR_NOT_FOUND) {
-            LOG_INFO("MainThread: read \"%s\" not found, init set_next to 0", set_next_key);
+            LOG_INFO_F("MainThread: read \"{}\" not found, init set_next to 0", set_next_key);
             set_next.store(0);
             break;
         } else {

--- a/src/test/kill_test/kill_testor.cpp
+++ b/src/test/kill_test/kill_testor.cpp
@@ -145,7 +145,7 @@ dsn::error_code kill_testor::get_partition_info(bool debug_unhealthy,
                 info << "], ";
                 info << "last_committed_decree=" << p.last_committed_decree;
                 if (debug_unhealthy) {
-                    LOG_INFO("found unhealthy partition, %s", info.str().c_str());
+                    LOG_INFO_F("found unhealthy partition, {}", info.str());
                 } else {
                     LOG_DEBUG_F("found unhealthy partition, {}", info.str());
                 }
@@ -180,7 +180,7 @@ bool kill_testor::check_cluster_status()
             } else
                 return true;
         } else {
-            LOG_INFO("query partition status fail, try times = %d", try_count);
+            LOG_INFO_F("query partition status fail, try times = {}", try_count);
             sleep(1);
         }
         try_count += 1;

--- a/src/test/kill_test/killer_handler_shell.cpp
+++ b/src/test/kill_test/killer_handler_shell.cpp
@@ -28,6 +28,7 @@
 #include "utils/api_utilities.h"
 #include "utils/config_api.h"
 #include "utils/fmt_logging.h"
+#include "utils/safe_strerror_posix.h"
 
 namespace pegasus {
 namespace test {
@@ -78,9 +79,9 @@ bool killer_handler_shell::kill_meta(int index)
 {
     std::string cmd = generate_cmd(index, "meta", "stop");
     int res = system(cmd.c_str());
-    LOG_INFO("kill meta command: %s", cmd.c_str());
+    LOG_INFO_F("kill meta command: {}", cmd);
     if (res != 0) {
-        LOG_INFO("kill meta encounter error(%s)", strerror(errno));
+        LOG_INFO_F("kill meta encounter error({})", dsn::utils::safe_strerror(errno));
         return false;
     }
     return check("meta", index, "stop");
@@ -90,9 +91,9 @@ bool killer_handler_shell::kill_replica(int index)
 {
     std::string cmd = generate_cmd(index, "replica", "stop");
     int res = system(cmd.c_str());
-    LOG_INFO("kill replica command: %s", cmd.c_str());
+    LOG_INFO_F("kill replica command: {}", cmd);
     if (res != 0) {
-        LOG_INFO("kill meta encounter error(%s)", strerror(errno));
+        LOG_INFO_F("kill meta encounter error({})", dsn::utils::safe_strerror(errno));
         return false;
     }
     return check("replica", index, "stop");
@@ -108,9 +109,9 @@ bool killer_handler_shell::start_meta(int index)
 {
     std::string cmd = generate_cmd(index, "meta", "start");
     int res = system(cmd.c_str());
-    LOG_INFO("start meta command: %s", cmd.c_str());
+    LOG_INFO_F("start meta command: {}", cmd);
     if (res != 0) {
-        LOG_INFO("kill meta encounter error(%s)", strerror(errno));
+        LOG_INFO_F("kill meta encounter error({})", dsn::utils::safe_strerror(errno));
         return false;
     }
     return check("meta", index, "start");
@@ -121,9 +122,9 @@ bool killer_handler_shell::start_replica(int index)
     std::string cmd = generate_cmd(index, "replica", "start");
 
     int res = system(cmd.c_str());
-    LOG_INFO("start replica command: %s", cmd.c_str());
+    LOG_INFO_F("start replica command: {}", cmd);
     if (res != 0) {
-        LOG_INFO("kill meta encounter error(%s)", strerror(errno));
+        LOG_INFO_F("kill meta encounter error({})", dsn::utils::safe_strerror(errno));
         return false;
     }
     return check("meta", index, "start");

--- a/src/test/kill_test/partition_kill_testor.cpp
+++ b/src/test/kill_test/partition_kill_testor.cpp
@@ -38,14 +38,14 @@ partition_kill_testor::partition_kill_testor(const char *config_file) : kill_tes
 
 void partition_kill_testor::Run()
 {
-    LOG_INFO("begin the kill-partition");
+    LOG_INFO_F("begin the kill-partition");
     while (true) {
         if (!check_cluster_status()) {
-            LOG_INFO("check_cluster_status() failed");
+            LOG_INFO_F("check_cluster_status() failed");
         } else {
             run();
         }
-        LOG_INFO("sleep %d seconds before checking", kill_interval_seconds);
+        LOG_INFO_F("sleep {} seconds before checking", kill_interval_seconds);
         sleep(kill_interval_seconds);
     }
 }
@@ -53,7 +53,7 @@ void partition_kill_testor::Run()
 void partition_kill_testor::run()
 {
     if (partitions.size() == 0) {
-        LOG_INFO("partitions empty");
+        LOG_INFO_F("partitions empty");
         return;
     }
 

--- a/src/test/kill_test/process_kill_testor.cpp
+++ b/src/test/kill_test/process_kill_testor.cpp
@@ -96,7 +96,7 @@ bool process_kill_testor::verifier_process_alive()
 
 void process_kill_testor::Run()
 {
-    LOG_INFO("begin the kill-thread");
+    LOG_INFO_F("begin the kill-thread");
     while (true) {
         if (!check_cluster_status()) {
             stop_verifier_and_exit("check_cluster_status() fail, and exit");
@@ -105,7 +105,7 @@ void process_kill_testor::Run()
             stop_verifier_and_exit("the verifier process is dead");
         }
         run();
-        LOG_INFO("sleep %d seconds before checking", kill_interval_seconds);
+        LOG_INFO_F("sleep {} seconds before checking", kill_interval_seconds);
         sleep(kill_interval_seconds);
     }
 }
@@ -117,9 +117,9 @@ void process_kill_testor::run()
     }
 
     if (kill_round == 0) {
-        LOG_INFO("Number of meta-server: %d", _total_meta_count);
-        LOG_INFO("Number of replica-server: %d", _total_replica_count);
-        LOG_INFO("Number of zookeeper: %d", _total_zookeeper_count);
+        LOG_INFO_F("Number of meta-server: {}", _total_meta_count);
+        LOG_INFO_F("Number of replica-server: {}", _total_replica_count);
+        LOG_INFO_F("Number of zookeeper: {}", _total_zookeeper_count);
     }
     kill_round += 1;
     int meta_cnt = 0;
@@ -132,25 +132,26 @@ void process_kill_testor::run()
         replica_cnt = generate_one_number(0, _kill_replica_max_count);
         zk_cnt = generate_one_number(0, _kill_zk_max_count);
     }
-    LOG_INFO("************************");
-    LOG_INFO("Round [%d]", kill_round);
-    LOG_INFO("start kill...");
-    LOG_INFO("kill meta number=%d, replica number=%d, zk number=%d", meta_cnt, replica_cnt, zk_cnt);
+    LOG_INFO_F("************************");
+    LOG_INFO_F("Round [{}]", kill_round);
+    LOG_INFO_F("start kill...");
+    LOG_INFO_F(
+        "kill meta number={}, replica number={}, zk number={}", meta_cnt, replica_cnt, zk_cnt);
 
     if (!kill(meta_cnt, replica_cnt, zk_cnt)) {
         stop_verifier_and_exit("kill jobs failed");
     }
 
     auto sleep_time_random_seconds = generate_one_number(1, _sleep_time_before_recover_seconds);
-    LOG_INFO("sleep %d seconds before recovery", sleep_time_random_seconds);
+    LOG_INFO_F("sleep {} seconds before recovery", sleep_time_random_seconds);
     sleep(sleep_time_random_seconds);
 
-    LOG_INFO("start recover...");
+    LOG_INFO_F("start recover...");
     if (!start()) {
         stop_verifier_and_exit("recover jobs failed");
     }
-    LOG_INFO("after recover...");
-    LOG_INFO("************************");
+    LOG_INFO_F("after recover...");
+    LOG_INFO_F("************************");
 }
 
 bool process_kill_testor::kill(int meta_cnt, int replica_cnt, int zookeeper_cnt)
@@ -165,12 +166,12 @@ bool process_kill_testor::kill(int meta_cnt, int replica_cnt, int zookeeper_cnt)
         job_index_to_kill.clear();
         generate_random(job_index_to_kill, kill_counts[id], 1, total_count[id]);
         for (auto index : job_index_to_kill) {
-            LOG_INFO("start to kill %s@%d", job_type_str(_job_types[id]), index);
+            LOG_INFO_F("start to kill {}@{}", job_type_str(_job_types[id]), index);
             if (!kill_job_by_index(_job_types[id], index)) {
-                LOG_INFO("kill %s@%d failed", job_type_str(_job_types[id]), index);
+                LOG_INFO_F("kill {}@{} failed", job_type_str(_job_types[id]), index);
                 return false;
             }
-            LOG_INFO("kill %s@%d succeed", job_type_str(_job_types[id]), index);
+            LOG_INFO_F("kill {}@{} succeed", job_type_str(_job_types[id]), index);
         }
     }
     return true;
@@ -183,12 +184,12 @@ bool process_kill_testor::start()
     for (auto id : random_idxs) {
         std::vector<int> &job_index_to_kill = _job_index_to_kill[_job_types[id]];
         for (auto index : job_index_to_kill) {
-            LOG_INFO("start to recover %s@%d", job_type_str(_job_types[id]), index);
+            LOG_INFO_F("start to recover {}@{}", job_type_str(_job_types[id]), index);
             if (!start_job_by_index(_job_types[id], index)) {
-                LOG_INFO("recover %s@%d failed", job_type_str(_job_types[id]), index);
+                LOG_INFO_F("recover {}@{} failed", job_type_str(_job_types[id]), index);
                 return false;
             }
-            LOG_INFO("recover %s@%d succeed", job_type_str(_job_types[id]), index);
+            LOG_INFO_F("recover {}@{} succeed", job_type_str(_job_types[id]), index);
         }
     }
     return true;

--- a/src/test/pressure_test/main.cpp
+++ b/src/test/pressure_test/main.cpp
@@ -109,7 +109,7 @@ void test_set(int32_t qps)
     atomic_int qps_quota(qps);
     ::dsn::task_ptr quota_task = ::dsn::tasking::enqueue_timer(
         LPC_DEFAUT_TASK, nullptr, [&]() { qps_quota.store(qps); }, chrono::seconds(1));
-    LOG_INFO("start to test set, with qps(%d)", qps);
+    LOG_INFO_F("start to test set, with qps({})", qps);
     while (true) {
         if (qps_quota.load() >= 10) {
             qps_quota.fetch_sub(10);
@@ -132,7 +132,7 @@ void test_get(int32_t qps)
     dsn::task_ptr quota_task = dsn::tasking::enqueue_timer(
         LPC_DEFAUT_TASK, nullptr, [&]() { qps_quota.store(qps); }, chrono::seconds(1));
 
-    LOG_INFO("start to test get, with qps(%d)", qps);
+    LOG_INFO_F("start to test get, with qps({})", qps);
     while (true) {
         if (qps_quota.load() >= 10) {
             qps_quota.fetch_sub(10);
@@ -174,7 +174,7 @@ void test_del(int32_t qps)
     dsn::task_ptr quota_task = dsn::tasking::enqueue_timer(
         LPC_DEFAUT_TASK, nullptr, [&]() { qps_quota.store(qps); }, chrono::seconds(1));
 
-    LOG_INFO("start to test get, with qps(%d)", qps);
+    LOG_INFO_F("start to test get, with qps({})", qps);
     while (true) {
         if (qps_quota.load() >= 10) {
             qps_quota.fetch_sub(10);
@@ -223,7 +223,7 @@ int main(int argc, const char **argv)
         return -1;
     }
     initialize();
-    LOG_INFO("Initialize client and load config.ini succeed");
+    LOG_INFO_F("Initialize client and load config.ini succeed");
     cluster_name =
         dsn_config_get_value_string("pressureclient", "cluster_name", "onebox", "cluster name");
 
@@ -252,14 +252,14 @@ int main(int argc, const char **argv)
     CHECK_GT(qps, 0);
     CHECK(!op_name.empty(), "must assign operation name");
 
-    LOG_INFO("pressureclient %s qps = %d", op_name.c_str(), qps);
+    LOG_INFO_F("pressureclient {} qps = {}", op_name, qps);
 
     pg_client = pegasus_client_factory::get_client(cluster_name.c_str(), app_name.c_str());
     CHECK_NOTNULL(pg_client, "initialize pg_client failed");
 
     auto it = _all_funcs.find(op_name);
     if (it != _all_funcs.end()) {
-        LOG_INFO("start pressureclient with %s qps(%d)", op_name.c_str(), qps);
+        LOG_INFO_F("start pressureclient with {} qps({})", op_name, qps);
         it->second(qps);
     } else {
         CHECK(false, "Unknown operation name({})", op_name);

--- a/src/utils/api_utilities.h
+++ b/src/utils/api_utilities.h
@@ -87,7 +87,6 @@ extern void dsn_coredump();
             dsn_logf(__FILENAME__, __FUNCTION__, __LINE__, level, __VA_ARGS__);                    \
     } while (false)
 
-#define LOG_INFO(...) dlog(LOG_LEVEL_INFO, __VA_ARGS__)
 #define LOG_WARNING(...) dlog(LOG_LEVEL_WARNING, __VA_ARGS__)
 #define LOG_ERROR(...) dlog(LOG_LEVEL_ERROR, __VA_ARGS__)
 #define LOG_FATAL(...) dlog(LOG_LEVEL_FATAL, __VA_ARGS__)

--- a/src/utils/command_manager.h
+++ b/src/utils/command_manager.h
@@ -30,6 +30,7 @@
 
 #include "utils/api_utilities.h"
 #include "utils/autoref_ptr.h"
+#include "utils/fmt_logging.h"
 #include "utils/ports.h"
 #include "utils/singleton.h"
 #include "utils/synchronize.h"
@@ -107,10 +108,10 @@ inline std::string remote_command_set_bool_flag(bool &flag,
     } else {
         if (args[0] == "true") {
             flag = true;
-            LOG_INFO("set %s to true by remote command", flag_name);
+            LOG_INFO_F("set {} to true by remote command", flag_name);
         } else if (args[0] == "false") {
             flag = false;
-            LOG_INFO("set %s to false by remote command", flag_name);
+            LOG_INFO_F("set {} to false by remote command", flag_name);
         } else {
             ret_msg = "ERR: invalid arguments";
         }

--- a/src/utils/fail_point.cpp
+++ b/src/utils/fail_point.cpp
@@ -71,12 +71,12 @@ inline const char *task_type_to_string(fail_point::task_type t)
 {
     fail_point &p = REGISTRY.create_if_not_exists(name);
     p.set_action(action);
-    LOG_INFO("add fail_point [name: %s, task: %s(%s), frequency: %d%, max_count: %d]",
-             name.data(),
-             task_type_to_string(p.get_task()),
-             p.get_arg().data(),
-             p.get_frequency(),
-             p.get_max_count());
+    LOG_INFO_F("add fail_point [name: {}, task: {}({}), frequency: {}%, max_count: {}]",
+               name,
+               task_type_to_string(p.get_task()),
+               p.get_arg(),
+               p.get_frequency(),
+               p.get_max_count());
 }
 
 /*static*/ bool _S_FAIL_POINT_ENABLED = false;
@@ -152,7 +152,7 @@ const std::string *fail_point::eval()
         return nullptr;
     }
     _max_cnt--;
-    LOG_INFO("fail on %s", _name.data());
+    LOG_INFO_F("fail on {}", _name);
 
     switch (_task) {
     case Off:
@@ -161,7 +161,7 @@ const std::string *fail_point::eval()
     case Return:
         return &_arg;
     case Print:
-        LOG_INFO(_arg.data());
+        LOG_INFO_F(_arg);
         break;
     }
     return nullptr;

--- a/src/zookeeper/distributed_lock_service_zookeeper.cpp
+++ b/src/zookeeper/distributed_lock_service_zookeeper.cpp
@@ -134,7 +134,7 @@ error_code distributed_lock_service_zookeeper::initialize(const std::vector<std:
     }
     _lock_root = current.empty() ? "/" : current;
 
-    LOG_INFO("init distributed_lock_service_zookeeper succeed, lock_root = %s", _lock_root.c_str());
+    LOG_INFO_F("init distributed_lock_service_zookeeper succeed, lock_root = {}", _lock_root);
     // Notice: this reference is released in the finalize
     add_ref();
     return ERR_OK;

--- a/src/zookeeper/test/distributed_lock_zookeeper.cpp
+++ b/src/zookeeper/test/distributed_lock_zookeeper.cpp
@@ -68,9 +68,9 @@ public:
 
     error_code start(const std::vector<std::string> &args)
     {
-        LOG_INFO("name: %s, argc=%u", info().full_name.c_str(), args.size());
+        LOG_INFO_F("name: {}, argc={}", info().full_name, args.size());
         for (const std::string &s : args)
-            LOG_INFO("argv: %s", s.c_str());
+            LOG_INFO_F("argv: {}", s);
         while (!ss_start)
             std::this_thread::sleep_for(std::chrono::seconds(1));
 
@@ -87,10 +87,8 @@ public:
                 [this](error_code ec, const std::string &name, int version) {
                     EXPECT_TRUE(ERR_OK == ec);
                     EXPECT_TRUE(name == this->info().full_name);
-                    LOG_INFO("lock: error_code: %s, name: %s, lock version: %d",
-                             ec.to_string(),
-                             name.c_str(),
-                             version);
+                    LOG_INFO_F(
+                        "lock: error_code: {}, name: {}, lock version: {}", ec, name, version);
                 },
                 DLOCK_CALLBACK,
                 [](error_code, const std::string &, int) { CHECK(false, "session expired"); },
@@ -106,7 +104,7 @@ public:
             task_ptr unlock_task = _dlock_service->unlock(
                 "test_lock", info().full_name, true, DLOCK_CALLBACK, [](error_code ec) {
                     EXPECT_TRUE(ERR_OK == ec);
-                    LOG_INFO("unlock, error code: %s", ec.to_string());
+                    LOG_INFO_F("unlock, error code: {}", ec);
                 });
             unlock_task->wait();
             task_pair.second->cancel(false);
@@ -145,7 +143,7 @@ TEST(distributed_lock_service_zookeeper, simple_lock_unlock)
     while (!ss_finish)
         std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    LOG_INFO("actual result: %lld, expect_result:%lld", result, expect_reuslt);
+    LOG_INFO_F("actual result: {}, expect_result: {}", result, expect_reuslt);
     EXPECT_TRUE(result == expect_reuslt);
 }
 

--- a/src/zookeeper/zookeeper_session.cpp
+++ b/src/zookeeper/zookeeper_session.cpp
@@ -317,10 +317,10 @@ void zookeeper_session::global_watcher(
 {
     zookeeper_session *zoo_session = (zookeeper_session *)ctx;
     zoo_session->init_non_dsn_thread();
-    LOG_INFO(
-        "global watcher, type(%s), state(%s)", string_zoo_event(type), string_zoo_state(state));
+    LOG_INFO_F(
+        "global watcher, type({}), state({})", string_zoo_event(type), string_zoo_state(state));
     if (type != ZOO_SESSION_EVENT && path != nullptr)
-        LOG_INFO("watcher path: %s", path);
+        LOG_INFO_F("watcher path: {}", path);
 
     CHECK(zoo_session->_handle == handle, "");
     zoo_session->dispatch_event(type, state, type == ZOO_SESSION_EVENT ? "" : path);


### PR DESCRIPTION
https://github.com/apache/incubator-pegasus/issues/1305

This patch aim to use LOG_INFO_F instead of LOG_INFO for all the remain parts:
- Use `LOG_INFO_F` instead of `LOG_INFO`
- Use `LOG_INFO_PREFIX` instead of `LOG_INFO` for class `proxy_session`, `pegasus_server_impl `
- Use upper case for commands in class `redis_parser`
- Remove some commentted `LOG_INFO` code

TODO:
1. print dsn_primary_address in log is useless, since it must be itself in whose log, e.g. in `src/common/fs_manager.cpp`, `src/replica/replica_stub.cpp`
2. try to use `LOG_*_PREFIX` for class `policy_context`, `cold_backup_context`