### PR TITLE
Revert "chore(thirdparty): Bump gperftools to 2.13 (#1682)"

### DIFF
--- a/scripts/pack_server.sh
+++ b/scripts/pack_server.sh
@@ -120,7 +120,7 @@ if [ "$use_jemalloc" == "on" ]; then
     copy_file ./thirdparty/output/lib/libjemalloc.so.2 ${pack}/bin
     copy_file ./thirdparty/output/lib/libprofiler.so.0 ${pack}/bin
 else
-    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so ${pack}/bin
+    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so.4 ${pack}/bin
 fi
 
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/bin

--- a/scripts/pack_tools.sh
+++ b/scripts/pack_tools.sh
@@ -129,7 +129,7 @@ if [ "$use_jemalloc" == "on" ]; then
     copy_file ./thirdparty/output/lib/libjemalloc.so.2 ${pack}/lib/
     copy_file ./thirdparty/output/lib/libprofiler.so.0 ${pack}/lib/
 else
-    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so ${pack}/lib/
+    copy_file ./thirdparty/output/lib/libtcmalloc_and_profiler.so.4 ${pack}/lib/
 fi
 
 copy_file ./thirdparty/output/lib/libboost*.so.1.69.0 ${pack}/lib/

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -97,9 +97,9 @@ ExternalProject_Get_property(googletest SOURCE_DIR)
 set(googletest_SRC ${SOURCE_DIR})
 
 ExternalProject_Add(gperftools
-        URL ${OSS_URL_PREFIX}/gperftools-2.13.tar.gz
-        https://github.com/gperftools/gperftools/releases/download/gperftools-2.13/gperftools-2.13.tar.gz
-        URL_MD5 4e218a40a354748c50d054c285caaae8
+        URL ${OSS_URL_PREFIX}/gperftools-2.7.tar.gz
+        https://github.com/gperftools/gperftools/releases/download/gperftools-2.7/gperftools-2.7.tar.gz
+        URL_MD5 c6a852a817e9160c79bdb2d3101b4601
         CONFIGURE_COMMAND ./configure --prefix=${TP_OUTPUT} --enable-static=no --enable-frame-pointers=yes
         BUILD_IN_SOURCE 1
         )


### PR DESCRIPTION
This reverts commit 3238686bf4ee062f819521817fc43f39bd70a548.

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how does it work?


### Checklist <!--REMOVE the items that are not applicable-->

##### Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

##### Code changes

- Has exported function/method change
- Has exported variable/fields change
- Has interface methods change
- Has persistent data change

##### Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

##### Related changes

- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
